### PR TITLE
test: fix two more flaky e2e tests with proper handler-level mocks

### DIFF
--- a/tests/test_end_to_end_integration.py
+++ b/tests/test_end_to_end_integration.py
@@ -197,12 +197,20 @@ class TestEndToEndIntegration:
 
     def test_outdated_applications_workflow(self, mock_applications, mock_homebrew_available):
         """Test outdated applications detection workflow."""
-        # Mock the check_outdated_apps function called inside the handler path
-        # to avoid real subprocess/Homebrew calls that would timeout.
-        mock_outdated = [
-            ("Firefox", "109.0", "110.0"),
-        ]
+        mock_outdated = [("Firefox", "109.0", "110.0")]
+        mock_app_tuples = [("Firefox", "110.0"), ("Visual Studio Code", "1.74.0")]
+        # The handler calls _get_apps_data() and _get_homebrew_casks() before reaching
+        # check_outdated_apps — mock them at the handler's local import level to prevent
+        # real system_profiler / brew subprocess calls regardless of test order.
         with (
+            mock.patch(
+                "versiontracker.handlers.outdated_handlers._get_installed_applications",
+                return_value=mock_app_tuples,
+            ),
+            mock.patch(
+                "versiontracker.handlers.outdated_handlers._get_homebrew_casks",
+                return_value=["firefox", "visual-studio-code"],
+            ),
             mock.patch(
                 "versiontracker.handlers.outdated_handlers.check_outdated_apps",
                 return_value=mock_outdated,
@@ -298,22 +306,22 @@ class TestEndToEndIntegration:
         results = []
 
         def run_versiontracker():
-            # Patch the handler's local import (imported by value, so source-module mock doesn't intercept)
-            with mock.patch("versiontracker.handlers.app_handlers._get_apps_data", return_value=mock_app_tuples):
-                with mock.patch("sys.argv", ["versiontracker", "--apps"]):
-                    result = versiontracker_main()
-                    results.append(result)
+            with mock.patch("sys.argv", ["versiontracker", "--apps"]):
+                result = versiontracker_main()
+                results.append(result)
 
-        # Run multiple instances concurrently
-        threads = []
-        for _ in range(3):
-            thread = threading.Thread(target=run_versiontracker)
-            threads.append(thread)
-            thread.start()
+        # Patch _get_apps_data once outside threads — mock.patch is not thread-safe;
+        # patching the same attribute from multiple threads simultaneously corrupts the
+        # save/restore chain and leaves the mock live after the test exits.
+        with mock.patch("versiontracker.handlers.app_handlers._get_apps_data", return_value=mock_app_tuples):
+            threads = []
+            for _ in range(3):
+                thread = threading.Thread(target=run_versiontracker)
+                threads.append(thread)
+                thread.start()
 
-        # Wait for all to complete
-        for thread in threads:
-            thread.join(timeout=30)
+            for thread in threads:
+                thread.join(timeout=30)
 
         # All should succeed
         assert len(results) == 3


### PR DESCRIPTION
## Summary

- **`test_concurrent_operations_workflow`**: Moved `mock.patch` outside threads. `mock.patch` is not thread-safe — patching the same attribute from 3 threads simultaneously corrupted the save/restore chain, leaving `_get_apps_data` mocked with Firefox data after the test, contaminating `test_handle_list_apps_with_export`.

- **`test_outdated_applications_workflow`**: Added mocks for `_get_installed_applications` and `_get_homebrew_casks` at the handler's local scope. The handler calls both before reaching `check_outdated_apps`, so they were making real `system_profiler`/`brew` subprocess calls. When a preceding test left the config's `brew_path` set to `/usr/local/bin/brew`, the test failed with "Command not found".

Both fixes are verified stable across 3 full test suite runs with different random seeds (2338 passed, 16 skipped each time).

## Test plan
- [ ] `pytest -q` passes 3× with different random seeds
- [ ] CI green on all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Stabilize flaky end-to-end workflows tests by tightening and correcting handler-level mocking around application data retrieval and concurrent execution.

Bug Fixes:
- Prevent real system_profiler and Homebrew subprocess calls in the outdated applications workflow test by mocking handler-local application and cask discovery functions.
- Avoid cross-thread mock corruption in the concurrent operations workflow test by applying the shared _get_apps_data patch outside of the spawned threads.

Tests:
- Refine e2e tests for outdated applications and concurrent operations workflows to use consistent handler-scoped mocks and reliable threading behavior.