### PR TITLE
deps: sync requirements files and add missing termcolor dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "tqdm>=4.65",
     "psutil>=6.0",
     "tabulate>=0.9.0",
+    "termcolor>=3.3.0",
     "aiohttp>=3.13.4",
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,23 +2,23 @@
 -r requirements.txt
 
 # Testing
-pytest>=7.4
+pytest>=8.0
 pytest-cov>=7.0
 pytest-timeout>=2.1
-pytest-mock>=3.11
-pytest-asyncio>=0.21.0
+pytest-mock>=3.14
+pytest-asyncio>=1.0
 
 # Code quality
-black>=23.7
-ruff>=0.1
-mypy>=1.5
-types-PyYAML>=6.0
+black>=26.3.1
+ruff>=0.4
+mypy>=1.10
+types-PyYAML>=6.0.12
 
 # Security
-bandit[toml]>=1.7
-pip-audit>=2.6
+bandit[toml]>=1.8
+pip-audit>=2.9
 
 # Build and release
-build>=0.10
-wheel>=0.41
-twine>=4.0
+build>=1.0
+wheel>=0.46.2
+twine>=6.0

--- a/requirements-py313.txt
+++ b/requirements-py313.txt
@@ -1,33 +1,35 @@
 # Python 3.13 compatible requirements
-# Updated: 2025-07-22
+# Updated: 2026-05-04
 
 # Core dependencies - verified Python 3.13 compatible
-fuzzywuzzy>=0.18.0
-rapidfuzz>=3.0.0  # Better performance than python-Levenshtein
 tqdm>=4.66.0
-PyYAML>=6.0
+PyYAML>=6.0.2
 termcolor>=3.3.0
 tabulate>=0.9.0
-psutil>=5.9.5
-aiohttp>=3.8.0
+psutil>=6.0.0
+aiohttp>=3.13.4
+
+# Optional dependencies
+fuzzywuzzy>=0.18.0  # optional: fuzzy matching (see [project.optional-dependencies].fuzzy)
+rapidfuzz>=3.0.0    # optional: faster alternative to fuzzywuzzy
 
 # Development dependencies - Python 3.13 compatible
 pytest>=8.0.0
 pytest-cov>=7.0.0
-pytest-asyncio>=0.23.0
+pytest-asyncio>=1.0.0
 pytest-timeout>=2.1.0
 pytest-xdist>=3.8.0
-pytest-mock>=3.11.0
+pytest-mock>=3.14.0
 
 # Type checking and linting - Python 3.13 compatible
-mypy>=1.8.0  # Updated for Python 3.13 support
-ruff>=0.1.0  # Modern linter with Python 3.13 support
-bandit[toml]>=1.7.5
+mypy>=1.10.0
+ruff>=0.4.0
+bandit[toml]>=1.8.0
 
 # Build and packaging
 build>=1.0.0
-wheel>=0.42.0
-twine>=4.0.2
+wheel>=0.46.2
+twine>=6.0.0
 
 # Pre-commit
 pre-commit>=4.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ pyyaml>=6.0.2
 tqdm>=4.65
 psutil>=6.0
 tabulate>=0.9.0
-aiohttp>=3.9.0
+termcolor>=3.3.0
+aiohttp>=3.13.4

--- a/versiontracker/ui.py
+++ b/versiontracker/ui.py
@@ -142,8 +142,8 @@ except ImportError:
     # Fallback implementation if termcolor is not available
     def colored(
         text: object,
-        color: str | None = None,
-        on_color: str | None = None,
+        color: str | tuple[int, int, int] | None = None,
+        on_color: str | tuple[int, int, int] | None = None,
         attrs: Iterable[str] | None = None,
         *,
         no_color: bool | None = None,
@@ -169,8 +169,8 @@ except ImportError:
 
     def cprint(
         text: object,
-        color: str | None = None,
-        on_color: str | None = None,
+        color: str | tuple[int, int, int] | None = None,
+        on_color: str | tuple[int, int, int] | None = None,
         attrs: Iterable[str] | None = None,
         *,
         no_color: bool | None = None,
@@ -359,14 +359,17 @@ def create_progress_bar() -> SmartProgress[Any]:
     return SmartProgress()
 
 
+_T = TypeVar("_T")
+
+
 # Enhanced version of tqdm with smart capabilities
-def smart_progress[T](
-    iterable: Iterable[T] | None = None,
+def smart_progress(  # noqa: UP047 — pydocstyle 6.3.0 cannot parse PEP 695 [T] syntax
+    iterable: Iterable[_T] | None = None,
     desc: str = "",
     total: int | None = None,
     monitor_resources: bool = True,
     **kwargs: Any,
-) -> Iterator[T]:
+) -> Iterator[_T]:
     """Create a smart progress bar.
 
     Args:


### PR DESCRIPTION
## Summary

- **Add `termcolor>=3.3.0` to `pyproject.toml` and `requirements.txt`** — it is used in `versiontracker/ui.py` (with a graceful fallback) but was not declared as a dependency, so `pip install macversiontracker` would not install it
- **Sync `requirements.txt`**: raise `aiohttp` floor from `>=3.9.0` to `>=3.13.4` to match `pyproject.toml`
- **Sync `requirements-dev.txt`**: all version floors now match `pyproject.toml` (`pytest`, `pytest-asyncio`, `pytest-mock`, `black`, `ruff`, `mypy`, `types-PyYAML`, `bandit`, `pip-audit`, `build`, `wheel`, `twine` were all behind)
- **Clean up `requirements-py313.txt`**: sync version floors with `pyproject.toml`, mark optional deps (`fuzzywuzzy`, `rapidfuzz`) with comments, update date stamp

## Test plan

- [x] Full test suite passes locally: **2338 passed, 16 skipped**
- [x] `termcolor` installed and `versiontracker/ui.py` imports resolve correctly
- [x] Pre-commit hooks pass on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Declare missing termcolor dependency and align dependency version floors across requirements files with pyproject.toml.

New Features:
- Add termcolor as an explicit runtime dependency in both pyproject.toml and requirements.txt.

Enhancements:
- Raise aiohttp minimum version in requirements.txt to match pyproject.toml.
- Synchronize development and Python 3.13-specific requirements with the dependency floors defined in pyproject.toml.