### PR TITLE
docs: update CHANGELOG and TODO to reflect current project state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Declared `termcolor` as a core dependency** (`>=3.3.0`): `versiontracker/ui.py`
+  imported `termcolor` with a graceful fallback but the package was never listed in
+  `pyproject.toml`, so `pip install macversiontracker` would silently skip it and
+  users would always get the colourless fallback (#145)
+- **Fallback `colored`/`cprint` type signatures** now include `tuple[int, int, int]`
+  for `color`/`on_color` parameters, matching termcolor's actual stubs — fixes two
+  mypy `[misc]` errors surfaced once the package gained type-stub resolution (#145)
+- **`smart_progress` generic syntax**: converted from PEP 695 `[T]` to classic
+  `TypeVar` + `# noqa: UP047` — pydocstyle 6.3.0 cannot parse the newer form and
+  raised a spurious D103 missing-docstring warning (#145)
+
+### Changed
+- **`requirements.txt`**: raised `aiohttp` floor from `>=3.9.0` to `>=3.13.4`; added
+  `termcolor>=3.3.0` — now matches `[project.dependencies]` in `pyproject.toml` (#145)
+- **`requirements-dev.txt`**: synced all version floors with `pyproject.toml`
+  (`pytest`, `pytest-asyncio`, `pytest-mock`, `black`, `ruff`, `mypy`, `types-PyYAML`,
+  `bandit`, `pip-audit`, `build`, `wheel`, `twine` were all behind) (#145)
+- **`requirements-py313.txt`**: synced version floors, marked optional deps
+  (`fuzzywuzzy`, `rapidfuzz`) with comments, updated date stamp (#145)
+
 ## [1.0.1] - 2026-04-01
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,12 @@
 # VersionTracker TODO
 
-## Current Status (March 2026)
+## Current Status (May 2026)
 
 ### Project Health
 
-- **Version**: 1.0.0 (stable)
-- **Tests**: 2,158 passing, 15 skipped
-- **Coverage**: ~78% overall
+- **Version**: 1.0.1 (stable)
+- **Tests**: 2,338 passing, 16 skipped
+- **Coverage**: ~78% overall (target: 85%)
 - **CI/CD**: All workflows passing on master (all green)
 - **Python Support**: 3.12+ (with 3.13 compatibility)
 - **Security**: 0 dependabot alerts, 0 secret scanning alerts, 0 CodeQL findings
@@ -16,6 +16,8 @@
 
 ### Recent Completions
 
+- ~~PR #145~~ **Dependency hygiene** — declared `termcolor` core dep, synced all
+  requirements files with `pyproject.toml`, fixed mypy type signatures in `ui.py`
 - ~~PR #118~~ **Dependency update** — `codecov/codecov-action` v5→v6
 - ~~PR #117~~ **Stabilisation P0–P5** — Homebrew cmd fix, progress config canonicalisation,
   CLI/handler drift, exception narrowing, README/TODO alignment
@@ -173,5 +175,5 @@ For detailed strategic planning see `docs/future_roadmap.md`.
 
 ---
 
-**Last Updated**: March 2026
+**Last Updated**: May 2026
 **Maintainer**: @docdyhr


### PR DESCRIPTION
## Summary

- Add `[Unreleased]` CHANGELOG entries for PR #145: declared `termcolor` as a core dep, synced all requirements files, fixed mypy type signatures in `ui.py`, resolved pydocstyle/ruff conflict on `smart_progress`
- Update TODO current status block: May 2026, v1.0.1, 2338 tests, add PR #145 to recent completions, correct last-updated date

## Test plan

- [x] Docs-only change — no code modified
- [x] markdownlint and all pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update documentation to reflect recent dependency, testing, and release status changes.

Documentation:
- Add Unreleased changelog entries documenting dependency declaration, type hint fixes, and requirement sync work from PR #145.
- Refresh TODO current status, recent completions, and last-updated metadata to match the May 2026 project state.