### PR TITLE
fix(ci): target main branch and add explicit workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: CI
 
 "on":
   push:
-    branches: [master, feature/*, hotfix/*]
+    branches: [main, master, feature/*, hotfix/*]
   pull_request:
-    branches: [master]
+    branches: [main, master]
   schedule:
     # Run performance regression tests daily at 2 AM UTC
     - cron: "0 2 * * *"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -7,8 +7,11 @@ on:
   workflow_dispatch:
 jobs:
   call:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: docdyhr/.github/.github/workflows/claude-dependabot-merge.yml@v1
-    secrets: inherit
+    secrets: inherit # pragma: allowlist secret
     with:
       max_budget_usd: "0.30"
       scope: all

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,9 +3,9 @@ name: Code Linting and Formatting
 
 "on":
   push:
-    branches: [master]
+    branches: [main, master]
   pull_request:
-    branches: [master]
+    branches: [main, master]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -3,9 +3,9 @@ name: Performance Testing
 
 "on":
   pull_request:
-    branches: [master]
+    branches: [main, master]
   push:
-    branches: [master]
+    branches: [main, master]
   schedule:
     # Run performance tests weekly on Sunday at 23:00 UTC
     - cron: "0 23 * * 0"
@@ -57,13 +57,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        python-version: ["3.13"]  # Use stable version for consistent results
+        python-version: ["3.13"] # Use stable version for consistent results
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0  # Need full history for performance comparison
+          fetch-depth: 0 # Need full history for performance comparison
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,9 +3,9 @@ name: Security Analysis
 
 "on":
   push:
-    branches: [master]
+    branches: [main, master]
   pull_request:
-    branches: [master]
+    branches: [main, master]
   workflow_dispatch:
   schedule:
     # Run comprehensive security checks daily at 6 AM UTC


### PR DESCRIPTION
## Summary

- All four CI workflows (`ci`, `lint`, `security`, `performance`) had `pull_request: branches: [master]` only — Dependabot PRs targeting `main` never triggered the required status checks, leaving all 10 open Dependabot PRs permanently blocked
- Adds `main` alongside `master` in all `push`/`pull_request` branch filters
- Adds explicit `permissions: contents: write / pull-requests: write` to `dependabot-auto-merge.yml`, resolving CodeQL alert #18 (`actions/missing-workflow-permissions`)
- Adds `# pragma: allowlist secret` to `secrets: inherit` line (detect-secrets false positive)

## Test plan

- [ ] CI, Lint, Security, Performance workflows trigger on this PR (targeting `main`)
- [ ] After merge, reopen or sync the 10 Dependabot PRs to trigger full CI runs on them
- [ ] CodeQL alert #18 closes once the permissions block is on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update GitHub workflows to properly run on the main branch and tighten permissions for Dependabot auto-merge.

Bug Fixes:
- Ensure CI, lint, security, and performance workflows trigger for pull requests and pushes targeting the main branch in addition to master.

Enhancements:
- Add explicit GitHub Actions permissions for contents and pull-requests in the Dependabot auto-merge workflow and mark inherited secrets as an allowed value for secret scanning tools.

CI:
- Adjust branch filters in all CI-related workflows so they run on both main and master branches.