### PR TITLE
chore: release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-05-28
+
 ### Fixed
+- **CI: sigstore action version** (`@v3` → `@v3.3.0`): the `@v3` tag does not exist in
+  `sigstore/gh-action-sigstore-python`; updated to the latest available tag so the
+  Sign and Attach to GitHub Release job no longer fails (#127)
+- **CI: production PyPI publish step** now includes `skip-existing: true`, matching the
+  TestPyPI step — prevents `400 Bad Request` errors when re-running the Release
+  workflow for a version already on PyPI (#128)
+- **CI: workflow permissions** — added explicit `permissions` blocks to all workflows
+  and retargeted push/pull_request triggers from `master` to `main`; resolves CodeQL
+  alert #18 and prevents spurious "branch not found" failures (#171)
 - **Declared `termcolor` as a core dependency** (`>=3.3.0`): `versiontracker/ui.py`
   imported `termcolor` with a graceful fallback but the package was never listed in
   `pyproject.toml`, so `pip install macversiontracker` would silently skip it and
@@ -27,16 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `bandit`, `pip-audit`, `build`, `wheel`, `twine` were all behind) (#145)
 - **`requirements-py313.txt`**: synced version floors, marked optional deps
   (`fuzzywuzzy`, `rapidfuzz`) with comments, updated date stamp (#145)
-
-## [1.0.1] - 2026-04-01
-
-### Fixed
-- **CI: sigstore action version** (`@v3` → `@v3.3.0`): the `@v3` tag does not exist in
-  `sigstore/gh-action-sigstore-python`; updated to the latest available tag so the
-  Sign and Attach to GitHub Release job no longer fails (#127)
-- **CI: production PyPI publish step** now includes `skip-existing: true`, matching the
-  TestPyPI step — prevents `400 Bad Request` errors when re-running the Release
-  workflow for a version already on PyPI (#128)
+- **Dependabot dependency bumps** (merged PRs #141–#170): `requests`, `virtualenv`,
+  `types-requests`, `packaging`, `types-tabulate`, `types-setuptools`, `tox`,
+  `urllib3`, `types-tqdm`, `python-levenshtein`, `sphinx`, `types-psutil`, `mypy`,
+  `coverage`, `filelock`, `sphinx-rtd-theme`, `anyio`, `vulture`, `pre-commit`,
+  `pytest-xdist`, `termcolor`, `trufflehog` (CI action) — all patch/minor bumps with
+  no breaking changes
 
 ### Security
 - **`black` dev dependency** bumped `>=24.0` → `>=26.3.1` (CVE-2026-32274): Black
@@ -589,3 +596,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Security scanning with bandit and pip-audit
 - Code quality checks with ruff and mypy
 - Multi-platform testing (Ubuntu, macOS)
+
+[Unreleased]: https://github.com/docdyhr/versiontracker/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/docdyhr/versiontracker/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/docdyhr/versiontracker/compare/v0.9.0...v1.0.0

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@
 ### 🔒 Security & Quality
 
 [![Code Coverage](https://img.shields.io/codecov/c/github/docdyhr/versiontracker/master?logo=codecov&logoColor=white&label=Codecov)](https://codecov.io/gh/docdyhr/versiontracker)
-[![Test Coverage](https://img.shields.io/badge/Coverage-70%2B%25-brightgreen?logo=pytest&logoColor=white)](https://github.com/docdyhr/versiontracker)
-[![Tests Passing](https://img.shields.io/badge/Tests-2%2C194%20Passing-success?logo=pytest&logoColor=white)](https://github.com/docdyhr/versiontracker/actions/workflows/ci.yml)
+[![Test Coverage](https://img.shields.io/badge/Coverage-86%25-brightgreen?logo=pytest&logoColor=white)](https://github.com/docdyhr/versiontracker)
+[![Tests Passing](https://img.shields.io/badge/Tests-2%2C385%20Passing-success?logo=pytest&logoColor=white)](https://github.com/docdyhr/versiontracker/actions/workflows/ci.yml)
 [![Security: Bandit](https://img.shields.io/badge/Bandit-Passing-success?logo=python&logoColor=white)](https://github.com/docdyhr/versiontracker/actions/workflows/security.yml)
 [![Security: pip-audit](https://img.shields.io/badge/pip--audit-No%20Vulnerabilities-success?logo=python&logoColor=white)](https://github.com/docdyhr/versiontracker/actions/workflows/security.yml)
 [![Security: Safety](https://img.shields.io/badge/Safety-No%20Vulnerabilities-success?logo=python&logoColor=white)](https://github.com/docdyhr/versiontracker/actions/workflows/security.yml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "macversiontracker"
-version = "1.0.0"
+version = "1.0.1"
 description = "A command-line tool for tracking and managing applications installed outside of the Mac App Store"
 readme = "README.md"
 license = "MIT"

--- a/versiontracker/__init__.py
+++ b/versiontracker/__init__.py
@@ -6,7 +6,7 @@ outside of the Mac App Store, with Homebrew cask integration.
 
 from typing import Any
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 from versiontracker.config import Config, get_config
 from versiontracker.exceptions import (


### PR DESCRIPTION
## Summary

- Bumps version `1.0.0` → `1.0.1` in `pyproject.toml` and `versiontracker/__init__.py`
- Consolidates all changes since the `v1.0.0` tag into the `CHANGELOG.md` `[1.0.1]` section (date: 2026-05-28)
- Updates README badges: Tests 2,194 → 2,385; Coverage 70%+ → 86%

### What's in this release

**Fixed**
- CI: sigstore action `@v3` → `@v3.3.0` (#127)
- CI: `skip-existing: true` on PyPI publish step (#128)
- CI: workflow permissions + `master` → `main` branch targets (#171)
- `termcolor` declared as core dependency in `pyproject.toml` (#145)
- Fallback `colored`/`cprint` type signatures (#145)
- `smart_progress` TypeVar / PEP 695 fix (#145)

**Changed**
- `requirements.txt`, `requirements-dev.txt`, `requirements-py313.txt` synced (#145)
- ~30 Dependabot dependency bumps (PRs #141–#170, #151, #156)

**Security**
- `black` bumped to `>=26.3.1` (CVE-2026-32274) (#129)

## Test plan

- [x] Full test suite green locally: 2,385 passed, 16 skipped
- [ ] CI passes all 5 required status checks
- [ ] Merge to main, tag `v1.0.1`, publish to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prepare the v1.0.1 release by bumping the package version, consolidating recent changes into the changelog, and updating documented test and coverage metrics.

Enhancements:
- Bump project version from 1.0.0 to 1.0.1 in packaging metadata and library entrypoint.

Documentation:
- Update CHANGELOG with a consolidated 1.0.1 release section and comparison links.
- Refresh README badges to reflect current test count and coverage percentage.