### PR TITLE
fix(ci): fix release workflow failures on retry and cross-repo push

### DIFF
--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -48,9 +48,9 @@ jobs:
 
       - name: Clone tap repository
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAP_PAT: ${{ secrets.TAP_PAT }}
         run: |
-          gh repo clone "${TAP_REPO}" homebrew-tap
+          git clone "https://x-access-token:${TAP_PAT}@github.com/${TAP_REPO}.git" homebrew-tap
           cd homebrew-tap
           echo "Current formula:"
           head -10 "${FORMULA_PATH}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ name: Release
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false  # Never cancel in-progress releases
+  cancel-in-progress: false # Never cancel in-progress releases
 
 permissions:
   contents: read
@@ -313,6 +313,7 @@ jobs:
           gh release upload
           '${{ github.ref_name }}' dist/**
           --repo '${{ github.repository }}'
+          --clobber
 
   # ---------------------------------------------------------------------------
   # Post-release verification (smoke tests from PyPI)


### PR DESCRIPTION
## Summary

- **`release.yml`**: Added `--clobber` to `gh release upload` — previously a re-run of the sign-and-attach job would fail with "asset under the same name already exists" because sigstore files were already present from the first run
- **`release-homebrew.yml`**: Replaced `GITHUB_TOKEN` with `TAP_PAT` for cloning `docdyhr/homebrew-tap` — `GITHUB_TOKEN` is scoped to the triggering repo and cannot push to a different repo, causing `fatal: could not read Username` on `git push origin main`

## Action required

Add a **`TAP_PAT`** repository secret: a GitHub Personal Access Token with `repo` scope on `docdyhr/homebrew-tap`. Without it, the Homebrew formula update job will fail at the clone step.

Settings → Secrets and variables → Actions → New repository secret → Name: `TAP_PAT`

## Test plan

- [ ] Confirm `TAP_PAT` secret is created with `repo` scope for `docdyhr/homebrew-tap`
- [ ] On next release, verify the Homebrew formula update job pushes successfully
- [ ] Verify re-running the sign-and-attach job no longer fails with duplicate-asset error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix release workflows to be resilient to retries and support cross-repo Homebrew tap updates.

CI:
- Use a dedicated TAP_PAT token to clone and push to the external homebrew-tap repository in the Homebrew release workflow.
- Allow re-running the sign-and-attach job by clobbering existing assets when uploading release artifacts.