### PR TITLE
fix(deps): bump aiohttp to >=3.14.0 (CVE-2026-34993, CVE-2026-47265)

### DIFF
--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -50,6 +50,10 @@ jobs:
         env:
           TAP_PAT: ${{ secrets.TAP_PAT }}
         run: |
+          if [ -z "${TAP_PAT}" ]; then
+            echo "::error::TAP_PAT secret is not set. Add a GitHub PAT with 'repo' write access to ${TAP_REPO} as the TAP_PAT repository secret."
+            exit 1
+          fi
           git clone "https://x-access-token:${TAP_PAT}@github.com/${TAP_REPO}.git" homebrew-tap
           cd homebrew-tap
           echo "Current formula:"

--- a/constraints.txt
+++ b/constraints.txt
@@ -4,7 +4,8 @@
 # Python 3.12+ required as per pyproject.toml
 
 # Core dependencies
-aiohttp>=3.8.0,<4.0.0
+# aiohttp: CVE-2026-34993, CVE-2026-47265 - fixed in 3.14.0
+aiohttp>=3.14.0,<4.0.0
 
 # Security-critical indirect dependencies
 # filelock: GHSA-qmgc-5h2g-mvrw (TOCTOU) - fixed in 3.20.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "psutil>=6.0",
     "tabulate>=0.9.0",
     "termcolor>=3.3.0",
-    "aiohttp>=3.13.4",
+    "aiohttp>=3.14.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements-py313.txt
+++ b/requirements-py313.txt
@@ -7,7 +7,7 @@ PyYAML>=6.0.2
 termcolor>=3.3.0
 tabulate>=0.9.0
 psutil>=6.0.0
-aiohttp>=3.13.4
+aiohttp>=3.14.0
 
 # Optional dependencies
 fuzzywuzzy>=0.18.0  # optional: fuzzy matching (see [project.optional-dependencies].fuzzy)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ tqdm>=4.65
 psutil>=6.0
 tabulate>=0.9.0
 termcolor>=3.3.0
-aiohttp>=3.13.4
+aiohttp>=3.14.0


### PR DESCRIPTION
## Summary

- Bumps `aiohttp` minimum version from `3.13.4` to `3.14.0` to address two security vulnerabilities
- Updates `pyproject.toml`, `requirements.txt`, `requirements-py313.txt`, and `constraints.txt`
- Improves Homebrew release workflow to fail-fast with a clear error when `TAP_PAT` is unset

**CVEs fixed:**
- CVE-2026-34993 — fixed in aiohttp 3.14.0
- CVE-2026-47265 — fixed in aiohttp 3.14.0

## Test plan
- [ ] CI passes (aiohttp 3.14.x is a minor version bump; async HTTP operations unchanged)
- [ ] `pip-audit` reports no aiohttp vulnerabilities after bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update dependency constraints for aiohttp and harden the Homebrew release workflow.

Bug Fixes:
- Raise the minimum aiohttp version to 3.14.0 across project dependency files to address known security vulnerabilities.

Enhancements:
- Improve the Homebrew release GitHub Actions workflow to fail fast with a clear error when the TAP_PAT secret is missing.

Build:
- Align aiohttp version constraints in pyproject and requirements files to require aiohttp>=3.14.0.