### PR TITLE
chore: add MIT license; remove duplicate dependabot-auto-merge schedule

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,9 +1,8 @@
 name: Claude Dependabot Auto-Merge
 # Migrated from inline blob (dependabot/fetch-metadata@v3) to reusable caller.
+# Schedule is owned by the cross-repo orchestrator in docdyhr/.github.
 # Claude Code reviews and merges eligible Dependabot PRs on schedule.
 on:
-  schedule:
-    - cron: "0 6 * * 0" # Sunday 06:00 UTC
   workflow_dispatch:
 jobs:
   call:


### PR DESCRIPTION
Tier 2 sweep — two changes:\n\n1. **MIT LICENSE** (copyright 2022 Thomas Juul Dyhr) — brings versiontracker up to the docdyhr standard.\n2. **Remove `schedule:` from `dependabot-auto-merge.yml`** — same fix applied to httpcheck/malwarespotter/pigame in item 22. The cross-repo orchestrator in `docdyhr/.github` owns the Sunday 06:00 schedule; per-repo trigger causes duplicate API spend.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add repository licensing and adjust Dependabot auto-merge workflow triggering to rely on the shared cross-repo schedule.

CI:
- Remove the per-repository cron schedule from the Dependabot auto-merge workflow so it is only triggered by the shared orchestrator.

Chores:
- Add an MIT license file to align repository licensing with the docdyhr standard.