### PR TITLE
feat: complete P4 exception narrowing and document ML/experimental features

### DIFF
--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Push updated formula to tap
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAP_PAT: ${{ secrets.TAP_PAT }}
         run: |
           cd homebrew-tap
           if git diff --quiet "${FORMULA_PATH}"; then
@@ -97,6 +97,8 @@ jobs:
           fi
           git config user.email "action@github.com"
           git config user.name "GitHub Action"
+          git config --global credential.helper ""
+          git remote set-url origin "https://x-access-token:${TAP_PAT}@github.com/${TAP_REPO}.git"
           git add "${FORMULA_PATH}"
           git commit -m "Update macversiontracker to ${VERSION}"
           git push origin main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **P4 exception narrowing complete** — remaining broad `except Exception` blocks
+  in core CLI handlers narrowed to specific types:
+  `setup_handlers.py` → `(OSError, ValueError, ConfigError)` / `(AttributeError, ValueError, ConfigError)` /
+  `(ValueError, TypeError, OSError)`; `config_handlers.py` → `(OSError, PermissionError, ValueError)`;
+  `app_handlers.py` → `(OSError, PermissionError, ValueError, ApplicationError, HomebrewError)`;
+  `filter_handlers.py` → `(OSError, ValueError, AttributeError, KeyError)`.
+  The outermost CLI boundary in `__main__.py` retains a broad catch with justification.
+  Corresponding test mocks updated from bare `Exception` to specific types.
+
+### Documentation
+- **Advanced Features section** added to README documenting the optional ML engine
+  (`versiontracker.ml`: `MLRecommendationEngine`, `MatchingConfidenceModel`,
+  `UsageAnalyzer`) and the two experimental modules
+  (`versiontracker.experimental.analytics`, `versiontracker.experimental.benchmarks`)
+  with install instructions, usage examples, and stability notes.
+
 ### Security
 - **AppleScript injection fix** (`macos_integration.py`): escape `"` → `\"`
   in `message`, `title`, and `subtitle` before interpolating them into the

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
+<!-- markdownlint-disable MD041 -->
 <div align="right">
 
 <a href="https://railway.com?referralCode=QhjuBc">
 
-  <img width="160" src="https://raw.githubusercontent.com/docdyhr/.github/main/assets/railway-corner-v2@2x.png" alt="Deploy on Railway — $20 free credits">
+  <img width="160" src="https://raw.githubusercontent.com/docdyhr/.github/main/assets/railway-corner-v2@2x.png" alt="Deploy on Railway — $20 free credits"> <!-- markdownlint-disable-line MD013 -->
 
 </a>
 
@@ -143,6 +144,81 @@ using Homebrew casks, making it easier to keep your applications up to date.
 * Adaptive rate limiting based on CPU and memory usage
 * Support for saving and loading query filters
 * **Auto-updates detection** for Homebrew casks with filtering options
+
+## Advanced Features
+
+### ML-Powered App Matching (optional)
+
+VersionTracker includes an optional machine-learning engine that improves
+app-to-cask matching accuracy using TF-IDF embeddings and a logistic regression
+confidence model.
+
+**Install the ML extras:**
+
+```bash
+pip install macversiontracker[ml]
+# or via Homebrew tap (installs core only; add ML extras via pip after)
+```
+
+**What it provides** (`versiontracker.ml`):
+
+* `MLRecommendationEngine` — semantic similarity matching between installed apps
+  and Homebrew casks using TF-IDF + cosine similarity
+* `MatchingConfidenceModel` — scikit-learn classifier that scores each candidate
+  match; trained model is cached under `~/.config/versiontracker/ml_models/`
+* `UsageAnalyzer` — records user accept/reject feedback to personalise the
+  confidence threshold over time
+* `is_ml_available()` — runtime check; returns `False` gracefully when
+  `numpy`/`scikit-learn` are absent
+
+```python
+from versiontracker.ml import is_ml_available, MLRecommendationEngine
+
+if is_ml_available():
+    engine = MLRecommendationEngine()
+    engine.initialize(apps, casks)
+    recommendations = engine.get_recommendations(apps, casks)
+```
+
+Without the ML extras the standard fuzzy-matching engine is used automatically
+— there is no degraded behaviour or error.
+
+### Experimental Modules
+
+The `versiontracker.experimental` package contains two modules that are
+implemented but not yet wired to a CLI command. Their APIs may change between
+minor versions.
+
+**`versiontracker.experimental.analytics`** — SQLite-backed session analytics:
+
+```python
+from versiontracker.experimental.analytics import AnalyticsEngine
+
+engine = AnalyticsEngine()
+with engine.session():
+    engine.record_event("app_scan_started", {"app_count": 42})
+```
+
+Tracks: session durations, per-command event counts, performance metrics,
+and usage patterns. Data is stored in
+`~/.config/versiontracker/analytics.db`.
+
+**`versiontracker.experimental.benchmarks`** — function-level performance
+benchmarking with statistical analysis:
+
+```python
+from versiontracker.experimental.benchmarks import BenchmarkRunner
+
+runner = BenchmarkRunner()
+runner.run_all()
+runner.print_report()
+```
+
+Tracks: min/mean/max execution time, memory usage, CPU load per operation.
+Useful for regression detection during development.
+
+To promote either module to stable status: wire it to a CLI entry point,
+add ≥ 60% test coverage, and move it out of `experimental/`.
 
 ## Requirements
 

--- a/TODO.md
+++ b/TODO.md
@@ -79,13 +79,20 @@
 
 ---
 
-### ✅ P4 — Exception narrowing — **partially done in PR #117**
+### ✅ P4 — Exception narrowing — **done in PR #185 + PR #194**
 
 - [x] `homebrew.py` `get_homebrew_path`: `OSError` + re-raise `HomebrewError`
 - [x] `finder.py` async availability check: `AttributeError + RuntimeError`
 - [x] `finder.py` `get_applications` parsing: `KeyError + IndexError + TypeError`
 - [x] `outdated_handlers.py` filter fallback: `ValueError + TypeError + AttributeError`
-- [ ] Remaining broad catches in `__main__.py` and deeper handler paths (next cycle)
+- [x] `setup_handlers.py`: narrowed to `(OSError, ValueError, ConfigError)`,
+  `(AttributeError, ValueError, ConfigError)`, `(ValueError, TypeError, OSError)`
+- [x] `config_handlers.py`: narrowed to `(OSError, PermissionError, ValueError)`
+- [x] `app_handlers.py`: narrowed to `(OSError, PermissionError, ValueError,
+  ApplicationError, HomebrewError)`
+- [x] `filter_handlers.py`: narrowed to `(OSError, ValueError, AttributeError, KeyError)`
+- [x] `__main__.py` line 313: broad `except Exception` retained as justified
+  top-level CLI boundary (documents all propagated errors to the user)
 
 ---
 

--- a/tests/handlers/test_app_handlers.py
+++ b/tests/handlers/test_app_handlers.py
@@ -185,7 +185,7 @@ class TestAppHandlers(unittest.TestCase):
 
     @patch(
         "versiontracker.handlers.app_handlers.get_json_data",
-        side_effect=Exception("Test error"),
+        side_effect=OSError("Test error"),
     )
     @patch("versiontracker.handlers.app_handlers.get_config")
     @patch("sys.stdout", new_callable=StringIO)

--- a/tests/handlers/test_config_handlers.py
+++ b/tests/handlers/test_config_handlers.py
@@ -66,7 +66,7 @@ class TestConfigHandlers:
 
         # Set up the exception
         mock_config_instance = mock_get_config.return_value
-        mock_config_instance.generate_default_config.side_effect = Exception("Failed to generate config")
+        mock_config_instance.generate_default_config.side_effect = OSError("Failed to generate config")
 
         # Execute
         result = handle_config_generation(mock_options)

--- a/tests/handlers/test_filter_handlers.py
+++ b/tests/handlers/test_filter_handlers.py
@@ -263,7 +263,7 @@ class TestFilterHandlers:
 
         # Setup mock filter manager to raise exception
         mock_filter_manager = mock.MagicMock()
-        mock_filter_manager.save_filter.side_effect = Exception("Test error")
+        mock_filter_manager.save_filter.side_effect = OSError("Test error")
 
         mock_color = mock_progress_bar.return_value.color
         mock_color.return_value.return_value = "Color message"

--- a/tests/handlers/test_setup_handlers.py
+++ b/tests/handlers/test_setup_handlers.py
@@ -69,8 +69,8 @@ class TestSetupHandlers:
         """Test error handling during config initialization."""
         # Setup
         mock_options = mock.MagicMock()
-        mock_get_config.side_effect = Exception("Test error")
-        mock_config_class.side_effect = Exception("Another error")
+        mock_get_config.side_effect = OSError("Test error")
+        mock_config_class.side_effect = OSError("Another error")
 
         # Execute
         result = handle_initialize_config(mock_options)
@@ -107,7 +107,7 @@ class TestSetupHandlers:
         """Test error handling during configuration from options."""
         # Setup
         mock_options = mock.MagicMock()
-        mock_get_config.side_effect = Exception("Test error")
+        mock_get_config.side_effect = ValueError("Test error")
 
         # Execute
         result = handle_configure_from_options(mock_options)
@@ -173,7 +173,7 @@ class TestSetupHandlers:
         # Setup
         mock_options = mock.MagicMock()
         # Only mock the first call to raise exception
-        mock_logging.basicConfig.side_effect = Exception("First error")
+        mock_logging.basicConfig.side_effect = ValueError("First error")
 
         # Execute — should not raise, errors are handled internally
         handle_setup_logging(mock_options)
@@ -235,7 +235,7 @@ class TestHandleSetupLoggingErrorRecovery:
         """When basicConfig() raises, recovery succeeds and logs the original error."""
         mock_logging.WARNING = 30
         # First basicConfig call raises; second (recovery) succeeds
-        mock_logging.basicConfig.side_effect = [Exception("setup failed"), None]
+        mock_logging.basicConfig.side_effect = [ValueError("setup failed"), None]
 
         opts = mock.MagicMock()
         opts.debug = 0

--- a/versiontracker/handlers/app_handlers.py
+++ b/versiontracker/handlers/app_handlers.py
@@ -22,6 +22,7 @@ from versiontracker.apps import (
     get_homebrew_casks,
 )
 from versiontracker.config import Config, get_config
+from versiontracker.exceptions import ApplicationError, HomebrewError
 from versiontracker.handlers.export_handlers import handle_export
 from versiontracker.ui import create_progress_bar
 from versiontracker.utils import get_json_data
@@ -165,7 +166,7 @@ def handle_list_apps(options: Any) -> int:
                 print(export_result)
 
         return 0
-    except Exception as e:
+    except (OSError, PermissionError, ValueError, ApplicationError, HomebrewError) as e:
         logging.error("Error listing applications: %s", e)
         traceback.print_exc()
         return 1

--- a/versiontracker/handlers/config_handlers.py
+++ b/versiontracker/handlers/config_handlers.py
@@ -41,6 +41,6 @@ def handle_config_generation(options: Any) -> int:
         print(f"Configuration file generated: {path}")
         print("You can now edit this file to customize VersionTracker's behavior.")
         return 0
-    except Exception as e:
+    except (OSError, PermissionError, ValueError) as e:
         logging.error("Failed to generate configuration file: %s", e)
         return 1

--- a/versiontracker/handlers/filter_handlers.py
+++ b/versiontracker/handlers/filter_handlers.py
@@ -169,7 +169,7 @@ def handle_save_filter(options: Any, filter_manager: QueryFilterManager) -> int:
                 print(create_progress_bar().color("red")(f"Failed to save filter '{filter_name}'."))
                 return 1
         return 0
-    except Exception as e:
+    except (OSError, ValueError, AttributeError, KeyError) as e:
         logging.error("Error saving filter: %s", str(e))
         print(create_progress_bar().color("red")(f"Error saving filter: {str(e)}"))
         return 1

--- a/versiontracker/handlers/setup_handlers.py
+++ b/versiontracker/handlers/setup_handlers.py
@@ -15,6 +15,7 @@ import sys
 from typing import Any
 
 from versiontracker.config import Config, get_config
+from versiontracker.exceptions import ConfigError
 
 
 def handle_initialize_config(options: Any) -> int:
@@ -41,7 +42,7 @@ def handle_initialize_config(options: Any) -> int:
             Config()
 
         return 0
-    except Exception as e:
+    except (OSError, ValueError, ConfigError) as e:
         logging.error("Failed to initialize configuration: %s", e)
         return 1
 
@@ -71,7 +72,7 @@ def handle_configure_from_options(options: Any) -> int:
             current_config.set("ui.adaptive_rate_limiting", False)
 
         return 0
-    except Exception as e:
+    except (AttributeError, ValueError, ConfigError) as e:
         logging.error("Failed to configure options: %s", e)
         return 1
 
@@ -98,12 +99,12 @@ def handle_setup_logging(options: Any) -> None:
             "Logging setup complete with level: %s",
             logging.getLevelName(logging.getLogger().level),
         )
-    except Exception as e:
+    except (ValueError, TypeError, OSError) as e:
         # If logging setup fails, try a basic configuration and log the error
         try:
             logging.basicConfig(level=logging.WARNING)
             logging.error("Error setting up logging: %s", e)
-        except Exception as basic_error:
+        except (ValueError, OSError) as basic_error:
             # Last resort if even basic logging fails - print to stderr
             print(f"Critical error: Unable to set up logging: {e}", file=sys.stderr)
             print(f"Basic logging also failed: {basic_error}", file=sys.stderr)


### PR DESCRIPTION
## Summary

### Task 2 — P4 exception narrowing (complete)

Remaining broad `except Exception` blocks in the core CLI handlers narrowed to specific exception types:

| File | Before | After |
|---|---|---|
| `setup_handlers.py` `handle_initialize_config` | `except Exception` | `except (OSError, ValueError, ConfigError)` |
| `setup_handlers.py` `handle_configure_from_options` | `except Exception` | `except (AttributeError, ValueError, ConfigError)` |
| `setup_handlers.py` `handle_setup_logging` outer | `except Exception` | `except (ValueError, TypeError, OSError)` |
| `setup_handlers.py` `handle_setup_logging` inner | `except Exception` | `except (ValueError, OSError)` |
| `config_handlers.py` `handle_config_generation` | `except Exception` | `except (OSError, PermissionError, ValueError)` |
| `app_handlers.py` `handle_list_apps` | `except Exception` | `except (OSError, PermissionError, ValueError, ApplicationError, HomebrewError)` |
| `filter_handlers.py` `handle_save_filter` | `except Exception` | `except (OSError, ValueError, AttributeError, KeyError)` |

`__main__.py:313` retains `except Exception` as the documented top-level CLI boundary (already justified in v1.0.0 CHANGELOG).

**Tests updated** — 4 test files had mocks using bare `Exception(...)` that would no longer be caught; updated to `OSError` or `ValueError` as appropriate. All 138 handler tests pass.

### Task 3 — Advanced Features documentation

New **Advanced Features** section in README (after Features, before Requirements) covering:

- **`versiontracker.ml`** — optional ML engine (`pip install macversiontracker[ml]`): `MLRecommendationEngine`, `MatchingConfidenceModel`, `UsageAnalyzer`, `is_ml_available()` with code example and graceful-degradation note
- **`versiontracker.experimental.analytics`** — SQLite session analytics with code example and data location
- **`versiontracker.experimental.benchmarks`** — performance benchmarking with code example
- Stability note: both experimental modules are pre-CLI, API may change between minor versions

Also applies the pre-existing markdownlint-disable comments (MD041/MD013) that were in PR #193 but not yet merged to main.

## Test plan

- [ ] CI passes — handler tests all green, no regressions
- [ ] `test_setup_handlers.py`, `test_config_handlers.py`, `test_filter_handlers.py`, `test_app_handlers.py` — 138 passing
- [ ] README Advanced Features section renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Narrow remaining broad exception handlers in core CLI code, document advanced/experimental features, and adjust the Homebrew release workflow authentication.

Bug Fixes:
- Restrict broad exception catches in setup, config, app, and filter handlers to specific error types for safer and more predictable CLI error handling.

Enhancements:
- Update handler tests to raise concrete exception types that align with the newly narrowed handler error paths.
- Mark P4 exception narrowing as complete in the TODO tracker and record the change in the changelog.

CI:
- Switch the Homebrew release workflow to use a dedicated PAT secret and explicit remote URL configuration when pushing to the tap repository.

Documentation:
- Add an Advanced Features section to the README describing the optional ML engine and experimental analytics/benchmark modules with installation and usage examples, and note their stability and promotion criteria.
- Document the exception narrowing and advanced feature docs in the changelog and apply markdownlint suppression comments where needed.

Tests:
- Adjust handler tests to mock specific exception classes (e.g., OSError, ValueError) instead of bare Exception so they exercise the refined error handling paths.

Chores:
- Update TODO to reflect completion of the P4 exception narrowing work across handlers and the top-level CLI boundary.