### PR TITLE
test: fix integration test mock paths for get_config and get_json_data

### DIFF
--- a/tests/integration/test_cli_workflows.py
+++ b/tests/integration/test_cli_workflows.py
@@ -53,10 +53,16 @@ class TestCLIWorkflows:
     def test_apps_export_to_file(self, tmp_path):
         """--apps --export json --output-file writes valid JSON to the target path."""
         output_file = tmp_path / "apps_export.json"
+        mock_cfg = mock.MagicMock()
+        mock_cfg.is_blocklisted.return_value = False
         with (
             mock.patch(
                 "versiontracker.handlers.app_handlers._get_apps_data",
                 return_value=_FAKE_APPS,
+            ),
+            mock.patch(
+                "versiontracker.handlers.app_handlers.get_config",
+                return_value=mock_cfg,
             ),
             mock.patch(
                 "sys.argv",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -163,14 +163,14 @@ class TestIntegration(unittest.TestCase):
         )
 
     @patch("versiontracker.config.check_dependencies", return_value=True)
-    @patch("versiontracker.apps.finder.get_applications")
-    @patch("versiontracker.utils.get_json_data")
-    @patch("versiontracker.ui.create_progress_bar")
+    @patch("versiontracker.handlers.app_handlers.get_applications")
+    @patch("versiontracker.handlers.app_handlers.get_json_data")
+    @patch("versiontracker.handlers.app_handlers.create_progress_bar")
     @patch("versiontracker.__main__.setup_logging")
-    @patch("versiontracker.config.Config")
+    @patch("versiontracker.handlers.app_handlers.get_config")
     def test_main_list_apps_workflow(
         self,
-        MockConfig,
+        mock_get_config,
         mock_setup_logging,
         mock_progress_bar,
         mock_get_json_data,
@@ -178,11 +178,13 @@ class TestIntegration(unittest.TestCase):
         mock_check_deps,
     ):
         """Test the main list apps workflow."""
-        mock_config_instance = MockConfig.return_value
+        mock_config_instance = mock_get_config.return_value
         mock_config_instance.is_blacklisted.return_value = False
+        mock_config_instance.is_blocklisted.return_value = False
         mock_config_instance.get.return_value = 10
         mock_config_instance.rate_limit = 10
         mock_config_instance.debug = False
+        mock_config_instance.system_profiler_cmd = "system_profiler -json SPApplicationsDataType"
 
         # Mock UI components
         mock_progress_bar.return_value = MagicMock(color=MagicMock(return_value=MagicMock(return_value="")))


### PR DESCRIPTION
## Summary

- `test_main_list_apps_workflow` was patching at the definition site, not the usage site in `app_handlers.py`
- Symbols imported by value meant mocks never intercepted calls, causing `shlex.split` to receive a MagicMock
- Fixed mock paths to `versiontracker.handlers.app_handlers.get_json_data`, `.get_config`, `.create_progress_bar`, and `.get_applications`
- Same fix applied to `test_apps_export_to_file` in `tests/integration/test_cli_workflows.py`

## Test plan
- [x] Failing test now passes
- [x] Full suite: 2482 passed, 16 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correct integration test mocks to patch configuration and app handler functions at their usage sites so CLI workflows are exercised with realistic config and app data.

Bug Fixes:
- Fix main list apps workflow integration test by patching app handler functions and configuration retrieval at the proper module paths.
- Ensure apps export CLI integration test provides a non-blocklisting config mock so JSON export runs against valid app data.