### PR TITLE
fix(ci): correct performance test CLI flag causing false regression failures

### DIFF
--- a/scripts/compare_performance.py
+++ b/scripts/compare_performance.py
@@ -13,6 +13,8 @@ from pathlib import Path
 REGRESSION_THRESHOLD = 0.05  # 5%
 TIME_ABSOLUTE_LIMIT = 30.0  # seconds
 MEMORY_ABSOLUTE_LIMIT = 500.0  # MB
+MIN_BASELINE_TIME = 0.05  # seconds; below this, relative deltas are just timing noise
+MIN_BASELINE_MEMORY = 1.0  # MB; ditto for memory
 
 
 def _load_json(path: Path) -> "dict | None":
@@ -36,10 +38,11 @@ def _check_absolute_limits(name: str, result: dict) -> list[str]:
 
 def _check_regression(name: str, current: dict, baseline: dict) -> list[str]:
     failures = []
+    min_baseline = {"avg_time": MIN_BASELINE_TIME, "avg_memory_mb": MIN_BASELINE_MEMORY}
     for metric, label in [("avg_time", "time"), ("avg_memory_mb", "memory")]:
         cur = current.get(metric, 0)
         base = baseline.get(metric, 0)
-        if base <= 0:
+        if base < min_baseline[metric]:
             continue
         delta = (cur - base) / base
         if delta > REGRESSION_THRESHOLD:

--- a/scripts/performance_test.py
+++ b/scripts/performance_test.py
@@ -6,13 +6,13 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 from versiontracker.__main__ import versiontracker_main as cli_main
 from versiontracker.profiling import disable_profiling, enable_profiling, generate_report, get_profiler
 
 
-def run_benchmark(command: str, iterations: int = 3) -> Dict[str, Any]:
+def run_benchmark(command: str, iterations: int = 3) -> dict[str, Any]:
     """Run a benchmark for a specific command."""
     print(f"Benchmarking: {command}")
 
@@ -77,7 +77,7 @@ def run_benchmark(command: str, iterations: int = 3) -> Dict[str, Any]:
     }
 
 
-def main():
+def main() -> None:
     """Main performance testing function."""
     target = os.environ.get("BENCHMARK_TARGET", "all")
 
@@ -86,7 +86,7 @@ def main():
         "apps": "--apps --no-progress",
         "brews": "--brews --no-progress",
         "recommend": "--recommend --no-progress",
-        "outdated": "--outdated --no-progress",
+        "outdated": "--check-outdated --no-progress",
     }
 
     if target != "all":


### PR DESCRIPTION
## Root Cause
`scripts/performance_test.py` benchmarked the CLI with `--outdated`, but the
actual flag is `--check-outdated` (see `versiontracker/cli.py`). Every run of
that benchmark has been silently failing via argparse's `SystemExit`
(swallowed by `run_benchmark`'s `except SystemExit: pass`), producing
near-zero fake timings (~0.003s) instead of a real measurement.

`scripts/compare_performance.py`'s regression check then flagged meaningless
percentage deltas on that near-zero baseline as a "regression" (e.g.
`0.003s → 0.003s` reported as `21.6% degraded`), failing the **Performance
Testing** workflow on `schedule`/`workflow_dispatch` runs. This is why the
most recent scheduled run (2026-07-05) failed and stayed red — it only runs
on schedule/manual dispatch, not on PRs, so it went unnoticed.

## Fix
- Correct the CLI flag: `--outdated` → `--check-outdated`.
- Harden `_check_regression` with `MIN_BASELINE_TIME` (0.05s) and
  `MIN_BASELINE_MEMORY` (1.0MB) floors so relative-delta regression checks
  are skipped below a noise threshold, preventing this class of false
  positive in the future. Absolute-limit warnings are unaffected.

## Verification
Confirmed via local simulation that the near-zero case is now filtered
while real regressions (e.g. 2.0s → 3.0s, 50% degraded) still correctly
fail. Pre-commit hooks (ruff, mypy, etc.) pass. Full CI will validate on
this PR; the Performance Testing workflow itself only runs on
schedule/workflow_dispatch so it won't re-trigger here, but the fix is
verified via the standalone script simulation described above.

---
*Auto-generated by /triage*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correct performance benchmarking of the CLI and make regression checks robust against near-zero baselines.

Bug Fixes:
- Fix performance test script to invoke the CLI with the correct outdated-check flag so benchmarks run instead of silently exiting.

Enhancements:
- Add minimum baseline thresholds for time and memory in the performance comparison script to ignore meaningless relative regressions on near-zero measurements.
- Tighten typing annotations in the performance test script for benchmark results and main entry point.