### PR TITLE
feat: add versiontracker --audit (unmanaged application audit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`versiontracker --audit`**: identifies user-facing applications that
+  aren't App Store-managed, aren't Homebrew-owned, have no confirmed local
+  auto-update path, and aren't blocklisted — with full per-signal evidence
+  (status, reason, confidence, source) rather than a bare yes/no. Evidence
+  that can't be resolved (e.g. a failed Homebrew CLI call) always surfaces
+  as `unknown` rather than silently becoming a false negative or positive.
+  New flags: `--audit`, `--all` (show every application, not just those
+  needing attention), `--status {attention,unknown,managed}` (filter to one
+  bucket), `--explain` (full evidence instead of a compact table); reuses
+  the existing `--export {json,yaml,csv}`/`--output-file`/
+  `--additional-dirs`/`--blocklist` flags. JSON/YAML exports carry a
+  versioned `schema_version` envelope with complete evidence for every
+  application, independent of `--explain`.
+
 ### Fixed
 - **Performance Testing baseline ratchet bug**: the scheduled weekly benchmark's
   baseline-save steps only ran `if: success()`, so once a run failed for any

--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ versiontracker --recommend
 # Check for outdated applications
 versiontracker --check-outdated
 
+# Audit apps not managed by the App Store, Homebrew, or a local auto-updater
+versiontracker --audit
+
 # Show help
 versiontracker --help
 ```
@@ -144,6 +147,9 @@ using Homebrew casks, making it easier to keep your applications up to date.
 * Adaptive rate limiting based on CPU and memory usage
 * Support for saving and loading query filters
 * **Auto-updates detection** for Homebrew casks with filtering options
+* **Unmanaged application audit** (`--audit`): identifies apps with no App
+  Store, Homebrew, or local auto-update coverage, with full per-signal
+  evidence and JSON/YAML/CSV export
 
 ## Advanced Features
 
@@ -319,6 +325,12 @@ Export options:
   --output-file OUTPUT_FILE
                         Specify the output file for export (default: print to stdout)
 
+Audit options (used with --audit):
+  --all                 Show every audited application, not just those needing attention
+  --status {attention,unknown,managed}
+                        Show only applications in this audit status
+  --explain             Show full evidence per application instead of a compact table
+
 Configuration options:
   --generate-config     Generate a default configuration file at ~/.config/versiontracker/config.yaml
   --config-path CONFIG_PATH
@@ -329,7 +341,8 @@ Configuration options:
   -a, --apps            return Apps in Applications/ that is not updated by App Store
   -b, --brews           return installable brews
   -r, --recommend       return recommendations for brew
-  -o, --outdated        check for outdated applications compared to Homebrew versions
+  -o, --check-outdated  check for outdated applications compared to Homebrew versions
+  --audit               audit apps not managed by the App Store, Homebrew, or a local auto-updater
   -V, --version         show program's version number and exit
 ```
 
@@ -362,13 +375,36 @@ python3 versiontracker-cli.py --recommend
 ### Check for outdated applications
 
 ```shell
-python3 versiontracker-cli.py --outdated
+python3 versiontracker-cli.py --check-outdated
 ```
 
 Or if installed:
 
 ```shell
-versiontracker --outdated
+versiontracker --check-outdated
+```
+
+### Audit unmanaged applications
+
+Identify user-facing applications that aren't App Store-managed, aren't
+Homebrew-owned, have no confirmed local auto-update path, and aren't
+blocklisted — with full per-signal evidence rather than a bare yes/no.
+
+```shell
+# Default view: applications needing attention or with incomplete evidence
+versiontracker --audit
+
+# Show every audited application, including already-managed ones
+versiontracker --audit --all
+
+# Show full evidence per application instead of a compact table
+versiontracker --audit --explain
+
+# Show only one audit status
+versiontracker --audit --status unknown
+
+# Export full evidence as versioned JSON
+versiontracker --audit --export json --output-file audit.json
 ```
 
 ### Handle applications with auto-updates
@@ -450,8 +486,8 @@ python -m versiontracker --install-service
 # Check service status
 python -m versiontracker --service-status
 
-# Send notification with outdated app results
-python -m versiontracker --outdated --notify
+# Check for outdated applications
+python -m versiontracker --check-outdated
 
 # Launch menubar application for quick access
 python -m versiontracker --menubar
@@ -744,7 +780,7 @@ and the tool is fully operational on macOS. Key highlights:
 
 * **macOS only** — VersionTracker runs on macOS only; Linux and Windows are not supported.
 * **macOS 10.15 Catalina or later** — older releases are not tested. Tested through macOS Sequoia.
-* **Homebrew required for version checks** — `--outdated` and `--recommend` require Homebrew;
+* **Homebrew required for version checks** — `--check-outdated` and `--recommend` require Homebrew;
   `--apps` works without it.
 * **Apple Silicon vs Intel** — both paths are detected automatically (`/opt/homebrew/bin/brew`
   and `/usr/local/bin/brew`). Mixed-architecture Rosetta environments may need a manual

--- a/TODO.md
+++ b/TODO.md
@@ -129,6 +129,145 @@ All skip decorators already carry a `reason=` string; no additional inline comme
 
 ---
 
+## Unmanaged Application Audit Feature (in progress)
+
+> Goal: `versiontracker audit` — identify user-facing apps that are not
+> App-Store-managed, not Homebrew-owned, have no confirmed auto-update path,
+> and aren't blocklisted, with full evidence per signal. Full spec at
+> `.claude/plans/versiontracker-unmanaged-apps-handoff.md` (gitignored).
+
+- [x] **Phase 1 — Models + identity-preserving discovery** —
+  `versiontracker/audit/{models,discovery}.py`, 59 new tests (94% coverage on
+  `discovery.py`, 100% on `models.py`). Filesystem-walk-based discovery (not a
+  `system_profiler`-JSON filter) with `Info.plist` + `_MASReceipt/receipt`
+  probes; validated live against this machine's `/Applications` (140 apps, 36
+  correctly classified App Store via the receipt signal alone).
+- [x] **Phase 2 — Exact Homebrew ownership + blocklist identity** —
+  `versiontracker/audit/{homebrew,blocklist}.py`, 46 new tests (95.89%
+  coverage on `blocklist.py`, 96.84% on `homebrew.py`). Ownership joins
+  discovered bundles to `brew info --json=v2 --cask --installed` app-artifact
+  `target` paths (zero fuzzy matching); blocklist matches canonical
+  path/bundle ID/Homebrew token/display name in that priority order. Fixed
+  two real bugs found during design review before they shipped: a
+  `run_command_secure` exception-handling gap that could crash the whole
+  audit on a missing `brew` binary instead of degrading to `unknown`, and a
+  cwd-dependent blocklist path-matching bug. Validated live against this
+  machine's `/Applications`: 45 apps correctly resolved `managed` with
+  correct cask tokens (e.g. `brave-browser`, `google-chrome`, `dropbox`), 94
+  `not_available`, 0 `unknown`.
+- [x] **Phase 3 — Local auto-update evidence** —
+  `versiontracker/audit/auto_update.py`, 65 new tests (97.49% coverage).
+  Five independent local probes (Sparkle framework + `SUEnableAutomaticChecks`,
+  Squirrel framework + ShipIt, electron-updater's `app-update.yml`, Mozilla's
+  `updater.app`, and vendor LaunchAgents/Daemons tied to a bundle ID or a
+  small curated vendor table) aggregate into one evidence result; a Homebrew
+  cask `auto_updates` flag supplements only when local probes found nothing.
+  Design review independently verified every claim against this machine's
+  real files, installed apps, and live `launchctl`/permission behaviour, and
+  found 6 real gaps before they shipped (unstable Sparkle framework version
+  letters, a Logi Options+ filename/Label mismatch, a root-owned/unreadable
+  Teams updater daemon, empty-stub Keystone plists `launchctl` confirms
+  aren't loaded, a Dropbox bundle-ID mismatch, a missing GPGTools entry).
+  The live sanity pass itself then caught a 7th, real bug — `plistlib.load()`
+  can raise `xml.parsers.expat.ExpatError` on a genuinely malformed plist
+  (confirmed via an actual corrupt LaunchAgent on this machine), which
+  neither this module's nor Phase 1's `discovery.py::_read_info_plist`
+  excepted; both fixed to catch broadly, with regression tests. Validated
+  live against this machine's `/Applications`: 51 `capable`, 3 `enabled`, 85
+  `none_detected` — Cyberduck's real `SUEnableAutomaticChecks=false` resolves
+  exactly to the "explicitly disabled → capable, not enabled" exit
+  criterion; Dash and ChatGPT Atlas correctly resolve `enabled`; Teams and
+  Signal correctly aggregate multiple simultaneous mechanisms; ClamXAV's
+  keyword guard correctly includes its real `.HelperToolUpdater` daemon
+  while excluding non-updater siblings sharing the same bundle-id prefix;
+  Zoom (no Sparkle/Squirrel, no Homebrew app artifact) resolves via its real
+  `us.zoom.updater.login.check` LaunchAgent alone.
+- [x] **Phase 4 — CLI wiring, terminal renderer, JSON/YAML/CSV export** —
+  `versiontracker/audit/{service,rendering}.py` and
+  `versiontracker/handlers/audit_handlers.py` (all 100% coverage), plus the
+  `--audit`/`--all`/`--status`/`--explain` flags in `cli.py` and dispatch in
+  `__main__.py`. 63 new tests across `tests/audit/{test_service,
+  test_rendering}.py`, `tests/handlers/test_audit_handlers.py`, and additive
+  coverage in `test_cli.py`/`test_main.py`/`test_cli_workflows.py`. This is
+  the first phase with a user-visible surface — `versiontracker audit` is now
+  a real, runnable command. Design review caught several bugs before they
+  shipped: a classification condition that would have wrongly excluded a
+  future Homebrew `available` result from the attention view, `run_audit()`
+  never actually fetching real `system_profiler` data (would have silently
+  degraded App Store detection to medium-confidence on every real run), the
+  Homebrew-before-auto-update pipeline-order dependency, and a deprecation
+  warning's console hint leaking into `--export json` stdout. The live
+  sanity pass then caught a real, would-have-shipped bug of its own —
+  `--status managed` returned the correct summary counts but zero rows,
+  because `render_terminal()`'s "Managed" section was gated behind `--all`
+  even though `filter_result()` had already scoped `result.applications`
+  down to exactly the requested bucket; fixed by making section visibility
+  depend only on what's actually in the (already-filtered) result, matching
+  the function's own "never re-applies filtering" contract. Validated live
+  against this machine's real `/Applications` (152 apps: 48 attention, 0
+  unknown, 104 managed) — `--audit`, `--all --explain`, `--export json`
+  (byte-clean, schema-valid), `--status managed`/`--status unknown` all
+  correct, and a simulated Homebrew CLI failure correctly routes every
+  application to the `unknown` bucket with a populated error rather than a
+  false negative.
+- [x] **Phase 5 — Regression tests and documentation** —
+  `tests/audit/test_golden_fixture.py` (new): one `run_audit()` call over 7
+  synthetic apps proving the resolvers compose correctly (App Store,
+  Homebrew, auto-update, blocklist, and multiple simultaneous signals each
+  independently reaching `managed`), plus an isolated test proving a
+  Homebrew CLI failure produces `unknown`, never a silently-flipped
+  negative. CLI-level flag-output tests added to
+  `tests/integration/test_cli_workflows.py` proving `--all`/`--status`/
+  `--explain`/`--export json` each change observable `versiontracker_main()`
+  stdout. Targeted failure-injection tests added for two confirmed gaps: a
+  real `PermissionError` (not the existing malformed-content case) on a
+  blocklist path entry (`test_blocklist.py`) and on both LaunchAgent-plist
+  reads and directory listing (`test_auto_update.py`), the latter isolated
+  from the existing blanket-failure test so a *single* failing probe can't
+  be silently absorbed into `none_detected`. 12 new tests total, full suite
+  2715→2727 passed, 16 skipped.
+
+  Also opportunistic fixes found along the way: replaced
+  `tests/test_matcher_coverage.py::test_strict_mode_skips_matched`, which
+  mocked `partial_ratio` to always match — making it structurally
+  impossible to ever observe a `strict_mode`-specific effect — with a test
+  that honestly pins the real current behavior (see the known-bug note
+  below). Fixed a real, live, silently-shipping bug found during design
+  review: `versiontracker/menubar_app.py` and
+  `versiontracker/handlers/macos_handlers.py` both hard-coded the
+  nonexistent `--outdated` flag (the real flag is `--check-outdated`) —
+  every menubar "Check for Updates"/"Show Outdated Apps" click and every
+  `--install-service` scheduled background check has been failing silently
+  since introduction. Fixed both, added `tests/test_menubar_app.py` (zero
+  prior coverage) validating every menu command against the real argparse
+  parser so a future flag rename can't reintroduce this silently. Also
+  corrected the same stale `--outdated` in README.md (5 lines) and
+  `docs/AUTO_UPDATE_MANAGEMENT.md`, and added the missing audit-feature
+  documentation to `docs/USAGE.md` and `docs/ARCHITECTURE.md` (Phase 4 only
+  updated README/CHANGELOG/TODO).
+- [ ] Phase 6 — NLP (`versiontracker ask`) + Swift GUI consumers
+
+### Known, confirmed, separate bugs found during audit-feature work (not fixed — out of scope)
+
+- **`--strict-recommend` is non-functional as documented.**
+  `versiontracker/apps/matcher.py:filter_out_brews()`'s `candidates` list is
+  built but never returned or used, and both the `strict_mode=True` and
+  `False` branches `break` out of the match loop identically — so
+  `strict_mode` currently has zero effect on the function's return value.
+  README's own description ("find applications that can be newly installed
+  with Homebrew, not already in cask repository") does not match reality.
+  Fixing the actual logic needs a product decision this audit work doesn't
+  make (`candidates` is dead in *both* modes, so there's no "restore
+  intended behavior" to fall back to) — tracked here, not fixed.
+- **`HomebrewStatus.AVAILABLE` is a phantom status.** No resolver in
+  `versiontracker/audit/homebrew.py` ever produces it — cask availability
+  (a matching cask exists but doesn't own this installed bundle) was
+  deliberately deferred as a later enrichment per the Phase 2 spec. The
+  enum member, and `classify_record()`'s defensive handling of it, exist
+  for when this enrichment is eventually implemented.
+
+---
+
 ## Future Enhancements (post-stabilisation)
 
 ### Extended Package Manager Support

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,12 +23,12 @@ VersionTracker follows a modular, layered architecture designed for maintainabil
 ├─────────────────────────────────────────────────────────────┤
 │  CLI Interface (cli.py) │ UI Components (ui.py)             │
 └─────────────────────────────────────────────────────────────┘
-┌─────────────────────────────────────────────────────────────┐
-│                     Business Logic Layer                    │
-├─────────────────────────────────────────────────────────────┤
-│ App Discovery │ Version Analysis │ Recommendations │ Export │
-│   (apps.py)   │   (utils.py)     │   (handlers/)    │(export)│
-└─────────────────────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────────────────────────┐
+│                          Business Logic Layer                         │
+├───────────────────────────────────────────────────────────────────────┤
+│ App Discovery │ Version Analysis │ Recommendations │ Export │  Audit  │
+│   (apps.py)   │    (utils.py)    │   (handlers/)    │(export)│(audit/)│
+└───────────────────────────────────────────────────────────────────────┘
 ┌─────────────────────────────────────────────────────────────┐
 │                    Service Layer                           │
 ├─────────────────────────────────────────────────────────────┤
@@ -86,6 +86,32 @@ VersionTracker follows a modular, layered architecture designed for maintainabil
   - `get_installed_casks()`: List installed casks
   - `fetch_cask_info()`: Get cask metadata from API
   - `check_cask_versions()`: Version comparison
+
+#### `audit/` - Unmanaged Application Audit
+- **Purpose**: Answer "which user-facing applications are not managed by
+  the App Store, not owned by Homebrew, have no confirmed local auto-update
+  mechanism, and aren't blocklisted?" (`versiontracker --audit`), with full
+  evidence per signal rather than a bare yes/no. A failed lookup is always
+  reported as `unknown`, never silently treated as a negative.
+- **Submodules**:
+  - `models.py`: Frozen dataclasses for identity-preserving application
+    records and per-signal evidence (status, reason, confidence, source)
+  - `discovery.py`: Filesystem-walk-based bundle discovery and App Store
+    evidence (`Info.plist` + `_MASReceipt/receipt`, optional
+    `system_profiler` enrichment)
+  - `homebrew.py`: Exact Homebrew ownership via installed-cask artifact
+    target paths -- no fuzzy matching
+  - `blocklist.py`: Structured identity matching (canonical path, bundle
+    ID, Homebrew cask token, display name)
+  - `auto_update.py`: Local auto-update capability detection (Sparkle,
+    Squirrel, electron-updater, Mozilla updater, vendor LaunchAgents)
+  - `service.py`: Orchestrates the resolvers in dependency order and
+    classifies each record into attention/unknown/managed
+  - `rendering.py`: Pure terminal/JSON/YAML/CSV renderers -- never print;
+    printing is exclusively `handlers/audit_handlers.py`'s job
+- **Key Functions**:
+  - `run_audit()`: Discover once, resolve every evidence axis, classify
+  - `filter_result()`: Select attention/unknown/managed/all for display
 
 ### Infrastructure Modules
 

--- a/docs/AUTO_UPDATE_MANAGEMENT.md
+++ b/docs/AUTO_UPDATE_MANAGEMENT.md
@@ -157,7 +157,7 @@ versiontracker --brews --only-auto-updates --export json --output-file auto-upda
 
 ### Check for outdated apps, excluding those with auto-updates:
 ```bash
-versiontracker --outdated --exclude-auto-updates
+versiontracker --check-outdated --exclude-auto-updates
 ```
 
 ### Save filter for auto-update apps:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -144,6 +144,46 @@ versiontracker --recommend --similarity 60
 
 A higher threshold will reduce false positives but might miss some matches.
 
+### Auditing Unmanaged Applications
+
+`--audit` answers a narrower, more specific question than `--apps`: which
+user-facing applications are not managed by the App Store, not owned by
+Homebrew, have no confirmed local auto-update mechanism, and aren't
+blocklisted? Each application's result carries evidence -- status, reason,
+confidence, and source -- for all four signals, not just a yes/no. A signal
+that can't be resolved (e.g. a failed Homebrew lookup) is reported as
+`unknown`, never silently treated as a negative.
+
+```bash
+# Default view: only applications needing attention or with incomplete evidence
+versiontracker --audit
+
+# Show every audited application, including already-managed ones
+versiontracker --audit --all
+
+# Show full evidence per application instead of a compact table
+versiontracker --audit --explain
+
+# Show only one audit status
+versiontracker --audit --status attention
+versiontracker --audit --status unknown
+versiontracker --audit --status managed
+```
+
+Results can be exported with full evidence in any of the three supported
+formats, each carrying a versioned schema:
+
+```bash
+versiontracker --audit --export json
+versiontracker --audit --export yaml
+versiontracker --audit --export csv --output-file audit.csv
+```
+
+`--all` and `--status` are mutually exclusive (choosing a single status
+already implies not showing everything). `--additional-dirs` and
+`--blocklist`/`--blacklist` behave as documented above and merge with any
+configured `additional_app_dirs`/blocklist entries rather than replacing them.
+
 ## Examples
 
 ### Daily Usage

--- a/tests/audit/__init__.py
+++ b/tests/audit/__init__.py
@@ -1,0 +1,1 @@
+"""Test modules for the versiontracker.audit package (unmanaged app audit, Phase 1)."""

--- a/tests/audit/conftest.py
+++ b/tests/audit/conftest.py
@@ -1,0 +1,300 @@
+"""Shared fixtures/builders for versiontracker.audit tests.
+
+make_app_bundle creates a real, minimal .app bundle on disk
+(Contents/Info.plist, optionally Contents/_MASReceipt/receipt) so
+discovery.py's filesystem-based probes (Info.plist reads, MAS receipt checks)
+exercise real code paths instead of being mocked out. make_sp_entry/sp_data
+build the system_profiler JSON shape used only for enrichment-matching tests
+-- obtained_from isn't derivable from the filesystem, so those tests need a
+system_profiler entry too.
+"""
+
+from __future__ import annotations
+
+import plistlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def make_app_bundle(
+    base: Path,
+    name: str,
+    *,
+    version: str = "1.0",
+    bundle_id: str | None = "com.example.app",
+    has_mas_receipt: bool = False,
+    write_plist: bool = True,
+    extra_plist_keys: dict[str, Any] | None = None,
+) -> Path:
+    """Create a minimal real .app bundle under `base`.
+
+    Returns the bundle's own path (base/{name}.app) so callers can nest
+    further make_app_bundle() calls under bundle/"Contents"/"MacOS" to build
+    helper bundles for nesting tests. extra_plist_keys is merged into the
+    Info.plist before writing -- e.g. {"SUEnableAutomaticChecks": False} for
+    Sparkle-preference tests.
+    """
+    bundle_path = base / f"{name}.app"
+    contents = bundle_path / "Contents"
+    contents.mkdir(parents=True, exist_ok=True)
+
+    if write_plist:
+        plist_data: dict[str, Any] = {
+            "CFBundleName": name,
+            "CFBundleShortVersionString": version,
+        }
+        if bundle_id is not None:
+            plist_data["CFBundleIdentifier"] = bundle_id
+        if extra_plist_keys:
+            plist_data.update(extra_plist_keys)
+        with (contents / "Info.plist").open("wb") as f:
+            plistlib.dump(plist_data, f)
+
+    if has_mas_receipt:
+        receipt_dir = contents / "_MASReceipt"
+        receipt_dir.mkdir(parents=True, exist_ok=True)
+        (receipt_dir / "receipt").write_bytes(b"fake-receipt")
+
+    return bundle_path
+
+
+def make_sp_entry(
+    bundle_path: Path,
+    *,
+    obtained_from: str | None = None,
+    name: str | None = None,
+    version: str | None = None,
+    bundle_id: str | None = None,
+) -> dict[str, Any]:
+    """Build one SPApplicationsDataType-shaped entry for enrichment tests.
+
+    Only needed when a test cares about obtained_from (or wants to prove
+    system_profiler values take priority over Info.plist) -- the filesystem
+    alone can't provide obtained_from.
+    """
+    entry: dict[str, Any] = {"path": str(bundle_path)}
+    if name is not None:
+        entry["_name"] = name
+    if version is not None:
+        entry["version"] = version
+    if obtained_from is not None:
+        entry["obtained_from"] = obtained_from
+    if bundle_id is not None:
+        entry["bundle_id"] = bundle_id
+    return entry
+
+
+def sp_data(*entries: dict[str, Any]) -> dict[str, Any]:
+    """Wrap entries in the top-level SPApplicationsDataType envelope."""
+    return {"SPApplicationsDataType": list(entries)}
+
+
+def make_cask(
+    token: str,
+    *,
+    tap: str = "homebrew/cask",
+    installed: str | None = "1.0",
+    app_name: str | None = None,
+    app_target: str | None = None,
+    auto_updates: bool = False,
+) -> dict[str, Any]:
+    """Build one real-shaped installed-cask entry (as `brew info --json=v2
+    --cask --installed` returns it).
+
+    app_name=None omits the `app` artifact entirely -- covers the common
+    real-world case (23 of 69 installed casks on a real machine) of a cask
+    with no app artifact at all (fonts, CLI tools, pkg-only installers).
+    """
+    artifacts: list[dict[str, Any]] = []
+    if app_name is not None:
+        target = app_target if app_target is not None else f"/Applications/{app_name}"
+        artifacts.append({"app": [app_name], "target": target})
+
+    return {
+        "token": token,
+        "tap": tap,
+        "name": [token.replace("-", " ").title()],
+        "installed": installed,
+        "auto_updates": auto_updates,
+        "artifacts": artifacts,
+    }
+
+
+def make_installed_casks_payload(*casks: dict[str, Any]) -> dict[str, Any]:
+    """Wrap casks in the real `brew info --json=v2 --cask --installed` envelope."""
+    return {"formulae": [], "casks": list(casks)}
+
+
+def add_sparkle_framework(bundle_path: Path) -> Path:
+    """Add a minimal Contents/Frameworks/Sparkle.framework to an existing bundle.
+
+    Returns the framework path. Combine with make_app_bundle(...,
+    extra_plist_keys={"SUEnableAutomaticChecks": True/False}) to test the
+    enabled/disabled/unset preference cases.
+    """
+    framework_path = bundle_path / "Contents" / "Frameworks" / "Sparkle.framework"
+    framework_path.mkdir(parents=True, exist_ok=True)
+    return framework_path
+
+
+def add_squirrel_framework(bundle_path: Path, *, include_shipit: bool = True) -> Path:
+    """Add a minimal Contents/Frameworks/Squirrel.framework to an existing
+    bundle, with ShipIt nested inside Resources/ (matching real layout)."""
+    framework_path = bundle_path / "Contents" / "Frameworks" / "Squirrel.framework"
+    resources_path = framework_path / "Resources"
+    resources_path.mkdir(parents=True, exist_ok=True)
+    if include_shipit:
+        (resources_path / "ShipIt").write_bytes(b"")
+    return framework_path
+
+
+def add_electron_update_yml(
+    bundle_path: Path,
+    *,
+    provider: str | None = "generic",
+    url: str = "https://example.com/updates",
+    malformed: bool = False,
+) -> Path:
+    """Add a Contents/Resources/app-update.yml to an existing bundle."""
+    resources_path = bundle_path / "Contents" / "Resources"
+    resources_path.mkdir(parents=True, exist_ok=True)
+    yml_path = resources_path / "app-update.yml"
+    if malformed:
+        yml_path.write_text("not: valid: yaml: [", encoding="utf-8")
+    else:
+        lines = []
+        if provider is not None:
+            lines.append(f"provider: {provider}")
+        lines.append(f"url: {url}")
+        yml_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return yml_path
+
+
+def add_mozilla_updater(
+    bundle_path: Path,
+    *,
+    include_ini: bool = True,
+    include_launch_services_entry: bool = True,
+) -> Path:
+    """Add a Contents/MacOS/updater.app (+ corroborating files) to an
+    existing bundle, matching Firefox's real layout."""
+    updater_app = bundle_path / "Contents" / "MacOS" / "updater.app"
+    updater_app.mkdir(parents=True, exist_ok=True)
+
+    if include_ini:
+        ini_path = bundle_path / "Contents" / "Resources" / "updater.ini"
+        ini_path.parent.mkdir(parents=True, exist_ok=True)
+        ini_path.write_text("[Strings]\nTitle=Update\n", encoding="utf-8")
+
+    if include_launch_services_entry:
+        ls_path = bundle_path / "Contents" / "Library" / "LaunchServices" / "org.mozilla.updater"
+        ls_path.parent.mkdir(parents=True, exist_ok=True)
+        ls_path.write_bytes(b"")
+
+    return updater_app
+
+
+def make_launch_agent_plist(
+    directory: Path,
+    filename: str,
+    *,
+    label: str | None = "auto",
+    unreadable: bool = False,
+) -> Path:
+    """Create one *.plist file in `directory` (a fake LaunchAgents/Daemons dir).
+
+    filename should include the .plist suffix. label="auto" derives the
+    Label key from the filename stem (the common case); label=None omits
+    the Label key entirely (reproduces the real Google Keystone empty-stub
+    plist); an explicit different string reproduces the real Logi Options+
+    filename/Label mismatch. unreadable=True writes garbage bytes instead of
+    a valid plist, simulating an unreadable/corrupt file (content-level
+    failure, distinct from a permission error, which tests simulate via
+    monkeypatching per the project's established pattern).
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / filename
+    if unreadable:
+        path.write_bytes(b"not a plist")
+        return path
+
+    stem = filename[: -len(".plist")] if filename.endswith(".plist") else filename
+    data: dict[str, Any] = {}
+    if label == "auto":
+        data["Label"] = stem
+    elif label is not None:
+        data["Label"] = label
+    with path.open("wb") as f:
+        plistlib.dump(data, f)
+    return path
+
+
+@pytest.fixture
+def app_bundle_factory():
+    """Factory fixture wrapping make_app_bundle."""
+    return make_app_bundle
+
+
+@pytest.fixture
+def sp_entry_factory():
+    """Factory fixture wrapping make_sp_entry."""
+    return make_sp_entry
+
+
+@pytest.fixture
+def sp_data_factory():
+    """Factory fixture wrapping sp_data."""
+    return sp_data
+
+
+@pytest.fixture
+def hermetic_roots(tmp_path: Path) -> list[Path]:
+    """A roots list confined to tmp_path, for discover_applications(roots=...).
+
+    Never touches the real machine's /Applications or ~/Applications.
+    """
+    return [tmp_path]
+
+
+@pytest.fixture
+def cask_factory():
+    """Factory fixture wrapping make_cask."""
+    return make_cask
+
+
+@pytest.fixture
+def installed_casks_payload_factory():
+    """Factory fixture wrapping make_installed_casks_payload."""
+    return make_installed_casks_payload
+
+
+@pytest.fixture
+def sparkle_framework_factory():
+    """Factory fixture wrapping add_sparkle_framework."""
+    return add_sparkle_framework
+
+
+@pytest.fixture
+def squirrel_framework_factory():
+    """Factory fixture wrapping add_squirrel_framework."""
+    return add_squirrel_framework
+
+
+@pytest.fixture
+def electron_update_yml_factory():
+    """Factory fixture wrapping add_electron_update_yml."""
+    return add_electron_update_yml
+
+
+@pytest.fixture
+def mozilla_updater_factory():
+    """Factory fixture wrapping add_mozilla_updater."""
+    return add_mozilla_updater
+
+
+@pytest.fixture
+def launch_agent_plist_factory():
+    """Factory fixture wrapping make_launch_agent_plist."""
+    return make_launch_agent_plist

--- a/tests/audit/test_auto_update.py
+++ b/tests/audit/test_auto_update.py
@@ -1,0 +1,746 @@
+"""Tests for versiontracker.audit.auto_update."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import versiontracker.audit.auto_update as auto_update_module
+from versiontracker.audit.auto_update import (
+    _ProbeResult,
+    apply_auto_update_evidence,
+    build_launch_agent_index,
+    resolve_auto_update_evidence,
+)
+from versiontracker.audit.models import (
+    ApplicationRecord,
+    AppStoreEvidence,
+    AppStoreStatus,
+    AutoUpdateMechanism,
+    AutoUpdateStatus,
+    EvidenceConfidence,
+    EvidenceSource,
+    HomebrewEvidence,
+    HomebrewStatus,
+)
+
+
+def _make_record(
+    canonical_path: Path,
+    *,
+    bundle_id: str | None = None,
+    name: str = "App",
+    homebrew: HomebrewEvidence | None = None,
+) -> ApplicationRecord:
+    kwargs: dict[str, object] = {
+        "name": name,
+        "version": "1.0",
+        "path": canonical_path,
+        "canonical_path": canonical_path,
+        "bundle_id": bundle_id,
+        "obtained_from": None,
+        "parent_bundle_path": None,
+        "app_store": AppStoreEvidence(
+            status=AppStoreStatus.NOT_APP_STORE, reason="test", source=EvidenceSource.SYSTEM_PROFILER
+        ),
+    }
+    if homebrew is not None:
+        kwargs["homebrew"] = homebrew
+    return ApplicationRecord(**kwargs)  # type: ignore[arg-type]
+
+
+def _managed_homebrew_evidence(*, auto_updates: bool | None, token: str = "some-cask") -> HomebrewEvidence:
+    return HomebrewEvidence(
+        status=HomebrewStatus.MANAGED,
+        reason="test",
+        source=EvidenceSource.HOMEBREW_CLI,
+        matched_identifier=token,
+        cask_auto_updates=auto_updates,
+    )
+
+
+class TestProbeSparkle:
+    def test_absent_is_not_found(self, tmp_path, app_bundle_factory) -> None:
+        bundle = app_bundle_factory(tmp_path, "PlainApp")
+
+        result = auto_update_module._probe_sparkle(bundle)
+
+        assert result.found is False
+        assert result.mechanism == AutoUpdateMechanism.SPARKLE_FRAMEWORK
+
+    def test_present_without_preference_key_is_capable_unconfirmed(
+        self, tmp_path, app_bundle_factory, sparkle_framework_factory
+    ) -> None:
+        """Real basis: VLC's and ChatGPT's actual Info.plist have no
+        SUEnableAutomaticChecks key despite Sparkle.framework being present."""
+        bundle = app_bundle_factory(tmp_path, "VLC")
+        sparkle_framework_factory(bundle)
+
+        result = auto_update_module._probe_sparkle(bundle)
+
+        assert result.found is True
+        assert result.confidence == EvidenceConfidence.HIGH
+        assert result.enabled is None
+
+    def test_present_with_enabled_true(self, tmp_path, app_bundle_factory, sparkle_framework_factory) -> None:
+        bundle = app_bundle_factory(tmp_path, "SomeApp", extra_plist_keys={"SUEnableAutomaticChecks": True})
+        sparkle_framework_factory(bundle)
+
+        result = auto_update_module._probe_sparkle(bundle)
+
+        assert result.found is True
+        assert result.enabled is True
+
+    def test_present_with_enabled_false_is_capable_not_enabled(
+        self, tmp_path, app_bundle_factory, sparkle_framework_factory
+    ) -> None:
+        """Real basis: Cyberduck's actual Info.plist has SUEnableAutomaticChecks=false."""
+        bundle = app_bundle_factory(tmp_path, "Cyberduck", extra_plist_keys={"SUEnableAutomaticChecks": False})
+        sparkle_framework_factory(bundle)
+
+        result = auto_update_module._probe_sparkle(bundle)
+
+        assert result.found is True
+        assert result.enabled is False
+
+    def test_probe_error_sets_error_field(self, tmp_path, app_bundle_factory, monkeypatch) -> None:
+        bundle = app_bundle_factory(tmp_path, "App")
+
+        def raise_os_error(self: Path, *args: object, **kwargs: object) -> bool:
+            raise OSError("denied")
+
+        monkeypatch.setattr(Path, "is_dir", raise_os_error)
+
+        result = auto_update_module._probe_sparkle(bundle)
+
+        assert result.found is False
+        assert result.error is not None
+
+
+class TestProbeSquirrel:
+    def test_absent_is_not_found(self, tmp_path, app_bundle_factory) -> None:
+        bundle = app_bundle_factory(tmp_path, "PlainApp")
+
+        result = auto_update_module._probe_squirrel(bundle)
+
+        assert result.found is False
+
+    def test_present_with_shipit(self, tmp_path, app_bundle_factory, squirrel_framework_factory) -> None:
+        bundle = app_bundle_factory(tmp_path, "Discord")
+        squirrel_framework_factory(bundle, include_shipit=True)
+
+        result = auto_update_module._probe_squirrel(bundle)
+
+        assert result.found is True
+        assert result.confidence == EvidenceConfidence.HIGH
+        assert "ShipIt" in result.detail
+
+    def test_present_without_shipit(self, tmp_path, app_bundle_factory, squirrel_framework_factory) -> None:
+        bundle = app_bundle_factory(tmp_path, "App")
+        squirrel_framework_factory(bundle, include_shipit=False)
+
+        result = auto_update_module._probe_squirrel(bundle)
+
+        assert result.found is True
+        assert "ShipIt" not in result.detail
+
+    def test_probe_error_sets_error_field(self, tmp_path, app_bundle_factory, monkeypatch) -> None:
+        bundle = app_bundle_factory(tmp_path, "App")
+
+        def raise_os_error(self: Path, *args: object, **kwargs: object) -> bool:
+            raise OSError("denied")
+
+        monkeypatch.setattr(Path, "is_dir", raise_os_error)
+
+        result = auto_update_module._probe_squirrel(bundle)
+
+        assert result.found is False
+        assert result.error is not None
+
+
+class TestProbeElectronUpdaterYml:
+    def test_absent_is_not_found(self, tmp_path, app_bundle_factory) -> None:
+        bundle = app_bundle_factory(tmp_path, "PlainApp")
+
+        result = auto_update_module._probe_electron_updater_yml(bundle)
+
+        assert result.found is False
+
+    def test_present_valid_yaml(self, tmp_path, app_bundle_factory, electron_update_yml_factory) -> None:
+        bundle = app_bundle_factory(tmp_path, "Signal")
+        electron_update_yml_factory(bundle, provider="generic")
+
+        result = auto_update_module._probe_electron_updater_yml(bundle)
+
+        assert result.found is True
+        assert result.confidence == EvidenceConfidence.HIGH
+        assert "provider=generic" in result.detail
+
+    def test_present_malformed_yaml_still_found(
+        self, tmp_path, app_bundle_factory, electron_update_yml_factory
+    ) -> None:
+        bundle = app_bundle_factory(tmp_path, "App")
+        electron_update_yml_factory(bundle, malformed=True)
+
+        result = auto_update_module._probe_electron_updater_yml(bundle)
+
+        assert result.found is True
+        assert result.error is None
+
+    def test_present_non_dict_yaml_still_found_without_provider(self, tmp_path, app_bundle_factory) -> None:
+        """Valid YAML syntax that isn't a mapping at the top level (e.g. a
+        bare string) -- distinct from malformed/unparseable content."""
+        bundle = app_bundle_factory(tmp_path, "App")
+        resources = bundle / "Contents" / "Resources"
+        resources.mkdir(parents=True, exist_ok=True)
+        (resources / "app-update.yml").write_text("just a string\n", encoding="utf-8")
+
+        result = auto_update_module._probe_electron_updater_yml(bundle)
+
+        assert result.found is True
+        assert "provider=" not in result.detail
+
+    def test_probe_error_sets_error_field(self, tmp_path, app_bundle_factory, monkeypatch) -> None:
+        bundle = app_bundle_factory(tmp_path, "App")
+
+        def raise_os_error(self: Path, *args: object, **kwargs: object) -> bool:
+            raise OSError("denied")
+
+        monkeypatch.setattr(Path, "is_file", raise_os_error)
+
+        result = auto_update_module._probe_electron_updater_yml(bundle)
+
+        assert result.found is False
+        assert result.error is not None
+
+
+class TestProbeMozillaUpdater:
+    def test_absent_is_not_found(self, tmp_path, app_bundle_factory) -> None:
+        bundle = app_bundle_factory(tmp_path, "PlainApp")
+
+        result = auto_update_module._probe_mozilla_updater(bundle)
+
+        assert result.found is False
+
+    def test_present_alone_is_medium_confidence(self, tmp_path, app_bundle_factory, mozilla_updater_factory) -> None:
+        bundle = app_bundle_factory(tmp_path, "PartialFirefox")
+        mozilla_updater_factory(bundle, include_ini=False, include_launch_services_entry=False)
+
+        result = auto_update_module._probe_mozilla_updater(bundle)
+
+        assert result.found is True
+        assert result.confidence == EvidenceConfidence.MEDIUM
+
+    def test_present_with_corroboration_is_high_confidence(
+        self, tmp_path, app_bundle_factory, mozilla_updater_factory
+    ) -> None:
+        """Real basis: Firefox.app has all three (updater.app, updater.ini,
+        the LaunchServices entry)."""
+        bundle = app_bundle_factory(tmp_path, "Firefox")
+        mozilla_updater_factory(bundle, include_ini=True, include_launch_services_entry=True)
+
+        result = auto_update_module._probe_mozilla_updater(bundle)
+
+        assert result.found is True
+        assert result.confidence == EvidenceConfidence.HIGH
+
+
+class TestProbeVendorLaunchAgent:
+    def test_no_bundle_id_is_not_found(self, tmp_path) -> None:
+        record = _make_record(tmp_path / "App.app", bundle_id=None)
+
+        result = auto_update_module._probe_vendor_launch_agent(record, (), ())
+
+        assert result.found is False
+
+    def test_exact_tier_match_via_label(self, tmp_path, launch_agent_plist_factory) -> None:
+        launch_agent_plist_factory(tmp_path, "some-file.plist", label="com.microsoft.teams.TeamsUpdaterDaemon")
+        candidates, _ = build_launch_agent_index([tmp_path])
+        record = _make_record(tmp_path / "Teams.app", bundle_id="com.microsoft.teams")
+
+        result = auto_update_module._probe_vendor_launch_agent(record, candidates, ())
+
+        assert result.found is True
+        assert result.confidence == EvidenceConfidence.HIGH
+        assert result.matched_identifier == "com.microsoft.teams.TeamsUpdaterDaemon"
+
+    def test_exact_tier_match_via_filename_when_content_unreadable(self, tmp_path, launch_agent_plist_factory) -> None:
+        """Real basis: /Library/LaunchDaemons/com.microsoft.teams.TeamsUpdaterDaemon.plist
+        is mode 600, root-owned -- content unreadable live, only the filename usable."""
+        launch_agent_plist_factory(tmp_path, "com.microsoft.teams.TeamsUpdaterDaemon.plist", unreadable=True)
+        candidates, _ = build_launch_agent_index([tmp_path])
+        record = _make_record(tmp_path / "Teams.app", bundle_id="com.microsoft.teams")
+
+        result = auto_update_module._probe_vendor_launch_agent(record, candidates, ())
+
+        assert result.found is True
+        assert result.confidence == EvidenceConfidence.MEDIUM
+        assert result.matched_identifier == "com.microsoft.teams.TeamsUpdaterDaemon"
+
+    def test_exact_tier_excludes_non_updater_daemon_sharing_prefix(self, tmp_path, launch_agent_plist_factory) -> None:
+        """Real basis: ClamXAV's .Engine.plist and .HelperTool.plist share a
+        bundle-id prefix with the real .HelperToolUpdater.plist but are not
+        updaters -- the "update" keyword guard must exclude them."""
+        launch_agent_plist_factory(tmp_path, "engine.plist", label="uk.co.canimaansoftware.ClamXAV.Engine")
+        launch_agent_plist_factory(tmp_path, "helper.plist", label="uk.co.canimaansoftware.ClamXAV.HelperTool")
+        candidates, _ = build_launch_agent_index([tmp_path])
+        record = _make_record(tmp_path / "ClamXAV.app", bundle_id="uk.co.canimaansoftware.ClamXAV")
+
+        result = auto_update_module._probe_vendor_launch_agent(record, candidates, ())
+
+        assert result.found is False
+
+    def test_exact_tier_still_finds_real_updater_among_non_updater_siblings(
+        self, tmp_path, launch_agent_plist_factory
+    ) -> None:
+        launch_agent_plist_factory(tmp_path, "engine.plist", label="uk.co.canimaansoftware.ClamXAV.Engine")
+        launch_agent_plist_factory(tmp_path, "updater.plist", label="uk.co.canimaansoftware.ClamXAV.HelperToolUpdater")
+        candidates, _ = build_launch_agent_index([tmp_path])
+        record = _make_record(tmp_path / "ClamXAV.app", bundle_id="uk.co.canimaansoftware.ClamXAV")
+
+        result = auto_update_module._probe_vendor_launch_agent(record, candidates, ())
+
+        assert result.found is True
+        assert result.matched_identifier == "uk.co.canimaansoftware.ClamXAV.HelperToolUpdater"
+
+    def test_vendor_tier_matches_paired_prefixes_that_differ(self, tmp_path, launch_agent_plist_factory) -> None:
+        """Real basis: Dropbox's LaunchAgent labels are com.dropbox.* but
+        Dropbox.app's own real bundle id is com.getdropbox.dropbox -- a
+        naive single-shared-prefix design would never tie these together."""
+        launch_agent_plist_factory(tmp_path, "dropbox-update.plist", label="com.dropbox.dropboxmacupdate.xpcservice")
+        candidates, _ = build_launch_agent_index([tmp_path])
+        record = _make_record(tmp_path / "Dropbox.app", bundle_id="com.getdropbox.dropbox")
+
+        result = auto_update_module._probe_vendor_launch_agent(record, candidates, ())
+
+        assert result.found is True
+        assert result.confidence == EvidenceConfidence.LOW
+
+    def test_vendor_tier_matches_via_filename_when_label_is_empty_stub(
+        self, tmp_path, launch_agent_plist_factory
+    ) -> None:
+        """Real basis: com.google.keystone.agent.plist (both user and system
+        copies) are empty <dict/> stubs with no Label key at all."""
+        launch_agent_plist_factory(tmp_path, "com.google.keystone.agent.plist", label=None)
+        candidates, _ = build_launch_agent_index([tmp_path])
+        record = _make_record(tmp_path / "Chrome.app", bundle_id="com.google.Chrome")
+
+        result = auto_update_module._probe_vendor_launch_agent(record, candidates, ())
+
+        assert result.found is True
+        assert result.confidence == EvidenceConfidence.LOW
+        assert result.matched_identifier == "com.google.keystone.agent"
+
+    def test_no_match_is_not_found(self, tmp_path, launch_agent_plist_factory) -> None:
+        launch_agent_plist_factory(tmp_path, "com.unrelated.vendor.plist")
+        candidates, _ = build_launch_agent_index([tmp_path])
+        record = _make_record(tmp_path / "App.app", bundle_id="com.example.app")
+
+        result = auto_update_module._probe_vendor_launch_agent(record, candidates, ())
+
+        assert result.found is False
+
+    def test_scan_errors_are_threaded_through(self, tmp_path) -> None:
+        record = _make_record(tmp_path / "App.app", bundle_id="com.example.app")
+
+        result = auto_update_module._probe_vendor_launch_agent(record, (), ("could not list /some/dir",))
+
+        assert result.error == "could not list /some/dir"
+
+
+class TestBuildLaunchAgentIndex:
+    def test_scans_plist_files_only(self, tmp_path, launch_agent_plist_factory) -> None:
+        launch_agent_plist_factory(tmp_path, "com.example.updater.plist")
+        (tmp_path / "not-a-plist.txt").write_text("ignore me")
+
+        candidates, scan_errors = build_launch_agent_index([tmp_path])
+
+        assert len(candidates) == 1
+        assert candidates[0].filename_stem == "com.example.updater"
+        assert scan_errors == ()
+
+    def test_malformed_xml_plist_label_falls_back_to_filename_without_raising(self, tmp_path) -> None:
+        """Regression: confirmed live on a real machine that a genuinely
+        corrupt LaunchAgent plist (~/Library/LaunchAgents/com.docdyhr.
+        claude-dependabot.plist) raises xml.parsers.expat.ExpatError via
+        plistlib's XML parser -- distinct from (and not caught by)
+        OSError/ValueError/plistlib.InvalidFileException. A single corrupt
+        file must not crash the whole scan; the candidate survives with
+        label=None (filename_stem remains usable)."""
+        path = tmp_path / "com.example.updater.plist"
+        path.write_text("<?xml version='1.0'?><plist><dict><key>Foo</key><not-closed></plist>", encoding="utf-8")
+
+        candidates, scan_errors = build_launch_agent_index([tmp_path])
+
+        assert len(candidates) == 1
+        assert candidates[0].label is None
+        assert candidates[0].filename_stem == "com.example.updater"
+        assert scan_errors == ()
+
+    def test_permission_error_reading_plist_content_falls_back_to_filename(
+        self, monkeypatch, tmp_path, launch_agent_plist_factory
+    ) -> None:
+        """Distinct failure point from the malformed-XML test above: a real
+        PermissionError on the file open itself, not a content-parsing
+        error -- confirmed live in Phase 3 (a real root-owned, mode-600
+        Teams updater daemon on this machine). Simulated via monkeypatching
+        per this project's established pattern (see conftest.py's
+        make_launch_agent_plist docstring) rather than a real chmod, which
+        would be unreliable across CI users/environments."""
+        launch_agent_plist_factory(tmp_path, "com.example.updater.plist")
+
+        def _raise_permission_error(self: Path, *args: object, **kwargs: object) -> None:
+            raise PermissionError("denied")
+
+        monkeypatch.setattr(Path, "open", _raise_permission_error)
+
+        candidates, scan_errors = build_launch_agent_index([tmp_path])
+
+        assert len(candidates) == 1
+        assert candidates[0].label is None
+        assert candidates[0].filename_stem == "com.example.updater"
+        assert scan_errors == ()
+
+    def test_nonexistent_directory_contributes_scan_error_not_crash(self, tmp_path) -> None:
+        missing = tmp_path / "DoesNotExist"
+
+        candidates, scan_errors = build_launch_agent_index([missing])
+
+        assert candidates == ()
+        assert len(scan_errors) == 1
+
+    def test_one_bad_directory_does_not_abort_scanning_others(self, tmp_path, launch_agent_plist_factory) -> None:
+        missing = tmp_path / "DoesNotExist"
+        good_dir = tmp_path / "Good"
+        launch_agent_plist_factory(good_dir, "com.example.updater.plist")
+
+        candidates, scan_errors = build_launch_agent_index([missing, good_dir])
+
+        assert len(candidates) == 1
+        assert len(scan_errors) == 1
+
+    def test_plist_suffixed_directory_is_skipped(self, tmp_path) -> None:
+        (tmp_path / "weird.plist").mkdir()
+
+        candidates, scan_errors = build_launch_agent_index([tmp_path])
+
+        assert candidates == ()
+        assert scan_errors == ()
+
+
+class TestDefaultLaunchAgentDirs:
+    def test_includes_standard_locations(self, monkeypatch, tmp_path) -> None:
+        fake_home = tmp_path / "home"
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+        dirs = auto_update_module.default_launch_agent_dirs()
+
+        assert dirs == [
+            Path("/Library/LaunchDaemons"),
+            Path("/Library/LaunchAgents"),
+            fake_home / "Library" / "LaunchAgents",
+        ]
+
+
+class TestAggregateProbeResults:
+    def _result(self, **overrides: object) -> _ProbeResult:
+        defaults: dict[str, object] = {
+            "mechanism": AutoUpdateMechanism.SPARKLE_FRAMEWORK,
+            "found": False,
+            "confidence": EvidenceConfidence.NONE,
+            "detail": "test",
+        }
+        defaults.update(overrides)
+        return _ProbeResult(**defaults)  # type: ignore[arg-type]
+
+    def test_all_negative_no_errors_is_none_detected(self) -> None:
+        evidence = auto_update_module._aggregate_probe_results([self._result(), self._result()])
+
+        assert evidence.status == AutoUpdateStatus.NONE_DETECTED
+        assert evidence.confidence == EvidenceConfidence.MEDIUM
+
+    def test_one_positive_is_capable(self) -> None:
+        evidence = auto_update_module._aggregate_probe_results(
+            [self._result(found=True, confidence=EvidenceConfidence.HIGH, detail="Sparkle present")]
+        )
+
+        assert evidence.status == AutoUpdateStatus.CAPABLE
+        assert evidence.confidence == EvidenceConfidence.HIGH
+
+    def test_positive_with_enabled_true_is_enabled(self) -> None:
+        evidence = auto_update_module._aggregate_probe_results(
+            [self._result(found=True, confidence=EvidenceConfidence.HIGH, enabled=True)]
+        )
+
+        assert evidence.status == AutoUpdateStatus.ENABLED
+
+    def test_positive_survives_an_unrelated_probe_error(self) -> None:
+        results = [
+            self._result(found=True, confidence=EvidenceConfidence.HIGH, detail="Squirrel present"),
+            self._result(mechanism=AutoUpdateMechanism.MOZILLA_UPDATER, found=False, error="permission denied"),
+        ]
+
+        evidence = auto_update_module._aggregate_probe_results(results)
+
+        assert evidence.status == AutoUpdateStatus.CAPABLE
+        assert "permission denied" in evidence.reason
+        assert evidence.error is None
+
+    def test_no_positive_with_error_is_unknown(self) -> None:
+        evidence = auto_update_module._aggregate_probe_results([self._result(found=False, error="permission denied")])
+
+        assert evidence.status == AutoUpdateStatus.UNKNOWN
+        assert evidence.confidence == EvidenceConfidence.NONE
+        assert evidence.error == "permission denied"
+
+    def test_multiple_simultaneous_positives_populate_mechanisms(self) -> None:
+        """Real basis: LM Studio/Signal/TradingView/Antigravity carry both
+        Squirrel.framework and app-update.yml simultaneously."""
+        results = [
+            self._result(
+                mechanism=AutoUpdateMechanism.SQUIRREL_FRAMEWORK,
+                found=True,
+                confidence=EvidenceConfidence.HIGH,
+                detail="Squirrel present",
+            ),
+            self._result(
+                mechanism=AutoUpdateMechanism.ELECTRON_UPDATER_YML,
+                found=True,
+                confidence=EvidenceConfidence.HIGH,
+                detail="app-update.yml present",
+            ),
+        ]
+
+        evidence = auto_update_module._aggregate_probe_results(results)
+
+        assert set(evidence.mechanisms) == {
+            AutoUpdateMechanism.SQUIRREL_FRAMEWORK,
+            AutoUpdateMechanism.ELECTRON_UPDATER_YML,
+        }
+
+
+class TestHomebrewCaskSupplement:
+    def test_supplements_none_detected_with_true_auto_updates(self, tmp_path) -> None:
+        record = _make_record(tmp_path / "App.app", homebrew=_managed_homebrew_evidence(auto_updates=True))
+        base_evidence = auto_update_module._aggregate_probe_results([])
+
+        evidence = auto_update_module._apply_homebrew_cask_supplement(base_evidence, record)
+
+        assert evidence.status == AutoUpdateStatus.CAPABLE
+        assert evidence.mechanisms == (AutoUpdateMechanism.HOMEBREW_CASK_AUTO_UPDATES,)
+
+    def test_does_not_supplement_when_cask_auto_updates_false(self, tmp_path) -> None:
+        record = _make_record(tmp_path / "App.app", homebrew=_managed_homebrew_evidence(auto_updates=False))
+        base_evidence = auto_update_module._aggregate_probe_results([])
+
+        evidence = auto_update_module._apply_homebrew_cask_supplement(base_evidence, record)
+
+        assert evidence.status == AutoUpdateStatus.NONE_DETECTED
+
+    def test_does_not_override_unknown(self, tmp_path) -> None:
+        """An errored local probe plus a generic upstream flag doesn't
+        explain *why* the probe failed -- unknown must route to needs_review
+        distinctly, not be papered over."""
+        record = _make_record(tmp_path / "App.app", homebrew=_managed_homebrew_evidence(auto_updates=True))
+        base_evidence = auto_update_module._aggregate_probe_results(
+            [
+                _ProbeResult(
+                    mechanism=AutoUpdateMechanism.SPARKLE_FRAMEWORK,
+                    found=False,
+                    confidence=EvidenceConfidence.NONE,
+                    detail="",
+                    error="denied",
+                )
+            ]
+        )
+
+        evidence = auto_update_module._apply_homebrew_cask_supplement(base_evidence, record)
+
+        assert evidence.status == AutoUpdateStatus.UNKNOWN
+
+    def test_does_not_override_existing_positive(self, tmp_path) -> None:
+        record = _make_record(tmp_path / "App.app", homebrew=_managed_homebrew_evidence(auto_updates=True))
+        base_evidence = auto_update_module._aggregate_probe_results(
+            [
+                _ProbeResult(
+                    mechanism=AutoUpdateMechanism.SPARKLE_FRAMEWORK,
+                    found=True,
+                    confidence=EvidenceConfidence.HIGH,
+                    detail="Sparkle present",
+                )
+            ]
+        )
+
+        evidence = auto_update_module._apply_homebrew_cask_supplement(base_evidence, record)
+
+        assert evidence.mechanisms == (AutoUpdateMechanism.SPARKLE_FRAMEWORK,)
+
+    def test_never_produces_enabled(self, tmp_path) -> None:
+        record = _make_record(tmp_path / "App.app", homebrew=_managed_homebrew_evidence(auto_updates=True))
+        base_evidence = auto_update_module._aggregate_probe_results([])
+
+        evidence = auto_update_module._apply_homebrew_cask_supplement(base_evidence, record)
+
+        assert evidence.status != AutoUpdateStatus.ENABLED
+
+    def test_ordering_tolerant_when_homebrew_not_yet_resolved(self, tmp_path) -> None:
+        """No service.py enforces resolution order in this phase."""
+        record = _make_record(tmp_path / "App.app")  # homebrew defaults to NOT_EVALUATED
+        base_evidence = auto_update_module._aggregate_probe_results([])
+
+        evidence = auto_update_module._apply_homebrew_cask_supplement(base_evidence, record)
+
+        assert evidence.status == AutoUpdateStatus.NONE_DETECTED
+
+    def test_not_available_homebrew_status_does_not_supplement(self, tmp_path) -> None:
+        record = _make_record(
+            tmp_path / "App.app",
+            homebrew=HomebrewEvidence(
+                status=HomebrewStatus.NOT_AVAILABLE, reason="test", source=EvidenceSource.HOMEBREW_CLI
+            ),
+        )
+        base_evidence = auto_update_module._aggregate_probe_results([])
+
+        evidence = auto_update_module._apply_homebrew_cask_supplement(base_evidence, record)
+
+        assert evidence.status == AutoUpdateStatus.NONE_DETECTED
+
+
+class TestApplyAutoUpdateEvidence:
+    def test_hermetic_run_over_empty_dirs_is_none_detected(self, tmp_path, app_bundle_factory) -> None:
+        empty_launch_agent_dir = tmp_path / "EmptyLaunchAgents"
+        empty_launch_agent_dir.mkdir()
+        bundle = app_bundle_factory(tmp_path / "Applications", "PlainApp")
+        record = _make_record(bundle.resolve())
+
+        result = apply_auto_update_evidence([record], launch_agent_dirs=[empty_launch_agent_dir])
+
+        assert result[0].auto_update.status == AutoUpdateStatus.NONE_DETECTED
+
+    def test_sparkle_bundle_resolves_capable(self, tmp_path, app_bundle_factory, sparkle_framework_factory) -> None:
+        empty_launch_agent_dir = tmp_path / "EmptyLaunchAgents"
+        empty_launch_agent_dir.mkdir()
+        bundle = app_bundle_factory(tmp_path / "Applications", "SomeApp")
+        sparkle_framework_factory(bundle)
+        record = _make_record(bundle.resolve())
+
+        result = apply_auto_update_evidence([record], launch_agent_dirs=[empty_launch_agent_dir])
+
+        assert result[0].auto_update.status in (AutoUpdateStatus.CAPABLE, AutoUpdateStatus.ENABLED)
+
+    def test_original_records_are_not_mutated(self, tmp_path, app_bundle_factory) -> None:
+        empty_launch_agent_dir = tmp_path / "EmptyLaunchAgents"
+        empty_launch_agent_dir.mkdir()
+        bundle = app_bundle_factory(tmp_path / "Applications", "PlainApp")
+        record = _make_record(bundle.resolve())
+
+        apply_auto_update_evidence([record], launch_agent_dirs=[empty_launch_agent_dir])
+
+        assert record.auto_update.status == AutoUpdateStatus.NOT_EVALUATED
+
+    def test_default_dirs_used_when_none_given(self, monkeypatch, tmp_path, app_bundle_factory) -> None:
+        empty_launch_agent_dir = tmp_path / "EmptyLaunchAgents"
+        empty_launch_agent_dir.mkdir()
+        monkeypatch.setattr(auto_update_module, "default_launch_agent_dirs", lambda: [empty_launch_agent_dir])
+        bundle = app_bundle_factory(tmp_path / "Applications", "PlainApp")
+        record = _make_record(bundle.resolve())
+
+        result = apply_auto_update_evidence([record])
+
+        assert result[0].auto_update.status == AutoUpdateStatus.NONE_DETECTED
+
+
+class TestExitCriteria:
+    """The four exit criteria quoted verbatim from the handoff spec."""
+
+    def test_sparkle_fixture_is_capable_or_enabled(
+        self, tmp_path, app_bundle_factory, sparkle_framework_factory
+    ) -> None:
+        bundle = app_bundle_factory(tmp_path, "SparkleApp")
+        sparkle_framework_factory(bundle)
+        record = _make_record(bundle.resolve())
+
+        evidence = resolve_auto_update_evidence(record, launch_agent_candidates=())
+
+        assert evidence.status in (AutoUpdateStatus.CAPABLE, AutoUpdateStatus.ENABLED)
+
+    def test_squirrel_fixture_is_capable_or_enabled(
+        self, tmp_path, app_bundle_factory, squirrel_framework_factory
+    ) -> None:
+        bundle = app_bundle_factory(tmp_path, "SquirrelApp")
+        squirrel_framework_factory(bundle)
+        record = _make_record(bundle.resolve())
+
+        evidence = resolve_auto_update_evidence(record, launch_agent_candidates=())
+
+        assert evidence.status in (AutoUpdateStatus.CAPABLE, AutoUpdateStatus.ENABLED)
+
+    def test_clean_fixture_is_none_detected(self, tmp_path, app_bundle_factory) -> None:
+        """Real basis: /System/Applications/Preview.app has zero
+        Sparkle/Squirrel/updater files and zero SU* Info.plist keys."""
+        bundle = app_bundle_factory(tmp_path, "Preview")
+        record = _make_record(bundle.resolve())
+
+        evidence = resolve_auto_update_evidence(record, launch_agent_candidates=())
+
+        assert evidence.status == AutoUpdateStatus.NONE_DETECTED
+
+    def test_probe_failure_is_unknown(self, tmp_path, app_bundle_factory, monkeypatch) -> None:
+        bundle = app_bundle_factory(tmp_path, "App")
+        record = _make_record(bundle.resolve())
+
+        def raise_os_error(self: Path, *args: object, **kwargs: object) -> bool:
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "is_dir", raise_os_error)
+
+        evidence = resolve_auto_update_evidence(record, launch_agent_candidates=())
+
+        assert evidence.status == AutoUpdateStatus.UNKNOWN
+
+    def test_isolated_vendor_probe_permission_error_does_not_become_none_detected(
+        self, tmp_path, app_bundle_factory, monkeypatch
+    ) -> None:
+        """Isolated version of test_probe_failure_is_unknown above, which
+        fails ALL probes at once via Path.is_dir (incidentally also
+        breaking Sparkle/Squirrel, which share that check). Here only the
+        vendor LaunchAgent probe's directory listing fails via a real
+        PermissionError on iterdir() -- Sparkle/Squirrel/electron/Mozilla
+        all cleanly return "not found", no error -- proving the aggregator
+        doesn't average one real error away into NONE_DETECTED just
+        because four other probes were quietly negative."""
+        bundle = app_bundle_factory(tmp_path, "App")
+        record = _make_record(bundle.resolve())
+        broken_dir = tmp_path / "BrokenLaunchAgents"
+        broken_dir.mkdir()
+        real_iterdir = Path.iterdir
+
+        def _raise_for_broken_dir(self: Path):
+            if self == broken_dir:
+                raise PermissionError("denied")
+            return real_iterdir(self)
+
+        monkeypatch.setattr(Path, "iterdir", _raise_for_broken_dir)
+
+        result = apply_auto_update_evidence([record], launch_agent_dirs=[broken_dir])
+
+        assert result[0].auto_update.status == AutoUpdateStatus.UNKNOWN
+
+    def test_negative_caveat_text_is_not_a_positive_match(self, tmp_path) -> None:
+        """The design only ever reads the structured Homebrew auto_updates
+        boolean, never Homebrew's free-text caveats string -- confirmed here
+        by constructing a MANAGED record whose reason text sounds positive
+        but whose cask_auto_updates is False, proving text content is never
+        inspected."""
+        homebrew = HomebrewEvidence(
+            status=HomebrewStatus.MANAGED,
+            reason="Caveat: this application does not auto-update automatically",
+            source=EvidenceSource.HOMEBREW_CLI,
+            matched_identifier="some-cask",
+            cask_auto_updates=False,
+        )
+        record = _make_record(tmp_path / "App.app", homebrew=homebrew)
+        base_evidence = auto_update_module._aggregate_probe_results([])
+
+        evidence = auto_update_module._apply_homebrew_cask_supplement(base_evidence, record)
+
+        assert evidence.status == AutoUpdateStatus.NONE_DETECTED

--- a/tests/audit/test_blocklist.py
+++ b/tests/audit/test_blocklist.py
@@ -1,0 +1,255 @@
+"""Tests for versiontracker.audit.blocklist."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import versiontracker.audit.blocklist as blocklist_module
+from versiontracker.audit.blocklist import apply_blocklist_evidence, resolve_blocklist_evidence
+from versiontracker.audit.models import (
+    ApplicationRecord,
+    AppStoreEvidence,
+    AppStoreStatus,
+    BlocklistMatchKind,
+    BlocklistStatus,
+    EvidenceSource,
+    HomebrewEvidence,
+    HomebrewStatus,
+)
+from versiontracker.config import get_config
+from versiontracker.exceptions import ConfigError
+
+
+def _make_record(
+    *,
+    name: str = "Little Snitch",
+    canonical_path: Path = Path("/Applications/Little Snitch.app"),
+    bundle_id: str | None = None,
+    homebrew: HomebrewEvidence | None = None,
+) -> ApplicationRecord:
+    kwargs: dict[str, Any] = {
+        "name": name,
+        "version": "1.0",
+        "path": canonical_path,
+        "canonical_path": canonical_path,
+        "bundle_id": bundle_id,
+        "obtained_from": None,
+        "parent_bundle_path": None,
+        "app_store": AppStoreEvidence(
+            status=AppStoreStatus.NOT_APP_STORE, reason="test", source=EvidenceSource.SYSTEM_PROFILER
+        ),
+    }
+    if homebrew is not None:
+        kwargs["homebrew"] = homebrew
+    return ApplicationRecord(**kwargs)
+
+
+def _managed_homebrew_evidence(token: str) -> HomebrewEvidence:
+    return HomebrewEvidence(
+        status=HomebrewStatus.MANAGED,
+        reason="test",
+        source=EvidenceSource.HOMEBREW_CLI,
+        matched_identifier=token,
+    )
+
+
+class TestResolveBlocklistEvidenceMatrixRows:
+    """The three required-test-matrix rows, plus the path row from Acceptance Criteria."""
+
+    def test_blocklist_by_display_name(self) -> None:
+        record = _make_record(name="Little Snitch")
+
+        evidence = resolve_blocklist_evidence(record, ["Little Snitch"])
+
+        assert evidence.status == BlocklistStatus.BLOCKED
+        assert evidence.matched_by == BlocklistMatchKind.DISPLAY_NAME
+        assert evidence.matched_identifier == "Little Snitch"
+
+    def test_blocklist_by_bundle_id(self) -> None:
+        record = _make_record(name="Little Snitch", bundle_id="at.obdev.littlesnitch")
+
+        evidence = resolve_blocklist_evidence(record, ["at.obdev.littlesnitch"])
+
+        assert evidence.status == BlocklistStatus.BLOCKED
+        assert evidence.matched_by == BlocklistMatchKind.BUNDLE_ID
+
+    def test_blocklist_by_cask_token(self) -> None:
+        record = _make_record(name="Visual Studio Code", homebrew=_managed_homebrew_evidence("visual-studio-code"))
+
+        evidence = resolve_blocklist_evidence(record, ["visual-studio-code"])
+
+        assert evidence.status == BlocklistStatus.BLOCKED
+        assert evidence.matched_by == BlocklistMatchKind.HOMEBREW_TOKEN
+
+    def test_blocklist_by_canonical_path(self) -> None:
+        record = _make_record(canonical_path=Path("/Applications/Little Snitch.app").resolve())
+
+        evidence = resolve_blocklist_evidence(record, ["/Applications/Little Snitch.app"])
+
+        assert evidence.status == BlocklistStatus.BLOCKED
+        assert evidence.matched_by == BlocklistMatchKind.CANONICAL_PATH
+
+
+class TestResolveBlocklistEvidenceNoMatch:
+    def test_no_match_is_not_blocked(self) -> None:
+        record = _make_record(name="Firefox")
+
+        evidence = resolve_blocklist_evidence(record, ["Little Snitch", "Microsoft Defender"])
+
+        assert evidence.status == BlocklistStatus.NOT_BLOCKED
+
+    def test_empty_blocklist_is_not_blocked(self) -> None:
+        record = _make_record()
+
+        evidence = resolve_blocklist_evidence(record, [])
+
+        assert evidence.status == BlocklistStatus.NOT_BLOCKED
+
+    def test_non_string_entries_are_skipped_defensively(self) -> None:
+        record = _make_record(name="Firefox")
+
+        evidence = resolve_blocklist_evidence(record, [123, None, {"a": 1}, "Little Snitch"])  # type: ignore[list-item]
+
+        assert evidence.status == BlocklistStatus.NOT_BLOCKED
+
+
+class TestResolveBlocklistEvidenceTierPriority:
+    def test_bundle_id_wins_over_display_name(self) -> None:
+        record = _make_record(name="Firefox", bundle_id="Firefox")
+
+        evidence = resolve_blocklist_evidence(record, ["Firefox"])
+
+        assert evidence.matched_by == BlocklistMatchKind.BUNDLE_ID
+
+    def test_canonical_path_wins_over_bundle_id(self) -> None:
+        path = Path("/Applications/App.app").resolve()
+        record = _make_record(canonical_path=path, bundle_id=str(path))
+
+        evidence = resolve_blocklist_evidence(record, [str(path)])
+
+        assert evidence.matched_by == BlocklistMatchKind.CANONICAL_PATH
+
+    def test_falls_through_non_matching_tiers_to_display_name(self) -> None:
+        """bundle_id and Homebrew token are both present but don't match any
+        entry -- must fall all the way through to the weakest (display name)
+        tier rather than stopping at the first non-empty tier it checks."""
+        record = _make_record(
+            name="Little Snitch",
+            bundle_id="at.obdev.littlesnitch",
+            homebrew=_managed_homebrew_evidence("little-snitch"),
+        )
+
+        evidence = resolve_blocklist_evidence(record, ["some-other-token", "Little Snitch"])
+
+        assert evidence.status == BlocklistStatus.BLOCKED
+        assert evidence.matched_by == BlocklistMatchKind.DISPLAY_NAME
+
+
+class TestResolveBlocklistEvidenceCwdRegression:
+    def test_relative_entry_does_not_match_via_cwd(self, monkeypatch, tmp_path) -> None:
+        """Regression: a bare relative blocklist entry must never be resolved
+        against the process's cwd -- otherwise the same config could match or
+        not match depending on where versiontracker happens to be launched
+        from. cwd is set to the app's own parent directory, so a naive
+        Path(entry).resolve() would accidentally match if the guard were
+        missing."""
+        app_dir = tmp_path / "Applications"
+        app_dir.mkdir()
+        canonical_path = (app_dir / "Keynote.app").resolve()
+        monkeypatch.chdir(app_dir)
+        record = _make_record(name="Keynote App", canonical_path=canonical_path)
+
+        # "Keynote.app" is a bare relative fragment -- meant as a (wrong)
+        # display-name typo, not a path -- and must NOT match via
+        # cwd-relative resolution.
+        evidence = resolve_blocklist_evidence(record, ["Keynote.app"])
+
+        assert evidence.status == BlocklistStatus.NOT_BLOCKED
+
+    def test_absolute_entry_still_matches_regardless_of_cwd(self, monkeypatch, tmp_path) -> None:
+        app_dir = tmp_path / "Applications"
+        app_dir.mkdir()
+        canonical_path = (app_dir / "Keynote.app").resolve()
+        monkeypatch.chdir(tmp_path)  # deliberately not the app's own directory
+        record = _make_record(name="Keynote App", canonical_path=canonical_path)
+
+        evidence = resolve_blocklist_evidence(record, [str(canonical_path)])
+
+        assert evidence.status == BlocklistStatus.BLOCKED
+        assert evidence.matched_by == BlocklistMatchKind.CANONICAL_PATH
+
+
+class TestPathEntryPermissionErrorGracefulDegradation:
+    """_try_resolve_path_entry() catches (OSError, RuntimeError, ValueError)
+    around Path.resolve() -- PermissionError is a real OSError subtype a
+    user-controlled config entry can trigger (e.g. an unreadable mount
+    point), but nothing exercised that except-clause until now."""
+
+    def test_permission_error_falls_through_to_next_tier(self, monkeypatch) -> None:
+        def _raise_permission_error(self: Path) -> Path:
+            raise PermissionError("denied")
+
+        monkeypatch.setattr(Path, "resolve", _raise_permission_error)
+        record = _make_record(name="Test App", bundle_id="com.example.testapp")
+
+        evidence = resolve_blocklist_evidence(record, ["/Applications/Unreadable Mount/App.app", "com.example.testapp"])
+
+        assert evidence.status == BlocklistStatus.BLOCKED
+        assert evidence.matched_by == BlocklistMatchKind.BUNDLE_ID
+
+
+class TestHomebrewTokenTierGracefulDegradation:
+    """No service.py enforces resolution order in this phase -- blocklist
+    resolution must tolerate running before Homebrew resolution."""
+
+    def test_unresolved_homebrew_evidence_does_not_crash_and_skips_to_next_tier(self) -> None:
+        record = _make_record(name="Visual Studio Code")  # homebrew defaults to NOT_EVALUATED
+
+        evidence = resolve_blocklist_evidence(record, ["visual-studio-code"])
+
+        assert evidence.status == BlocklistStatus.NOT_BLOCKED
+
+    def test_matches_once_homebrew_evidence_is_resolved(self) -> None:
+        record = _make_record(name="Visual Studio Code", homebrew=_managed_homebrew_evidence("visual-studio-code"))
+
+        evidence = resolve_blocklist_evidence(record, ["visual-studio-code"])
+
+        assert evidence.status == BlocklistStatus.BLOCKED
+        assert evidence.matched_by == BlocklistMatchKind.HOMEBREW_TOKEN
+
+
+class TestApplyBlocklistEvidence:
+    def test_explicit_entries_used_when_given(self) -> None:
+        record = _make_record(name="Firefox")
+
+        result = apply_blocklist_evidence([record], ["Firefox"])
+
+        assert result[0].blocklist.status == BlocklistStatus.BLOCKED
+
+    def test_defaults_to_config_get_blocklist(self) -> None:
+        get_config().set("blocklist", ["Firefox"])
+        record = _make_record(name="Firefox")
+
+        result = apply_blocklist_evidence([record])
+
+        assert result[0].blocklist.status == BlocklistStatus.BLOCKED
+
+    def test_config_error_degrades_every_record_to_unknown(self, monkeypatch) -> None:
+        def raise_config_error() -> None:
+            raise ConfigError("malformed config")
+
+        monkeypatch.setattr(blocklist_module, "get_config", raise_config_error)
+        records = [_make_record(name="A"), _make_record(name="B")]
+
+        result = apply_blocklist_evidence(records)
+
+        assert all(r.blocklist.status == BlocklistStatus.UNKNOWN for r in result)
+        assert all(r.blocklist.error is not None for r in result)
+
+    def test_original_records_are_not_mutated(self) -> None:
+        record = _make_record(name="Firefox")
+
+        apply_blocklist_evidence([record], ["Firefox"])
+
+        assert record.blocklist.status == BlocklistStatus.NOT_EVALUATED

--- a/tests/audit/test_discovery.py
+++ b/tests/audit/test_discovery.py
@@ -1,0 +1,405 @@
+"""Tests for versiontracker.audit.discovery.
+
+All discovery calls pass an explicit `roots=` (directly, via `hermetic_roots`,
+or by monkeypatching default_discovery_roots) so tests never touch the real
+machine's /Applications or ~/Applications.
+"""
+
+from __future__ import annotations
+
+import plistlib
+from pathlib import Path
+
+import versiontracker.audit.discovery as discovery
+from versiontracker.audit.discovery import (
+    configured_discovery_roots,
+    default_discovery_roots,
+    discover_applications,
+    resolve_app_store_evidence,
+    resolve_discovery_roots,
+)
+from versiontracker.audit.models import (
+    AppStoreStatus,
+    AutoUpdateStatus,
+    BlocklistStatus,
+    EvidenceConfidence,
+    HomebrewStatus,
+)
+from versiontracker.config import get_config
+
+
+class TestRootResolution:
+    def test_default_roots_include_applications_and_home_applications(self, monkeypatch, tmp_path) -> None:
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+        roots = default_discovery_roots()
+
+        assert roots == [Path("/Applications"), fake_home / "Applications"]
+
+    def test_configured_roots_reads_via_config_get(self, tmp_path) -> None:
+        extra = tmp_path / "Extra"
+        extra.mkdir()
+        get_config().set("additional_app_dirs", [str(extra)])
+
+        roots = configured_discovery_roots()
+
+        assert roots == [extra]
+
+    def test_configured_roots_empty_by_default(self) -> None:
+        assert configured_discovery_roots() == []
+
+    def test_resolve_discovery_roots_merges_default_configured_and_extra(self, monkeypatch, tmp_path) -> None:
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+        configured_extra = tmp_path / "ConfiguredExtra"
+        configured_extra.mkdir()
+        get_config().set("additional_app_dirs", [str(configured_extra)])
+
+        cli_extra = tmp_path / "CliExtra"
+        cli_extra.mkdir()
+
+        roots = resolve_discovery_roots(extra_roots=[str(cli_extra)])
+
+        assert Path("/Applications").resolve() in roots
+        assert (fake_home / "Applications").resolve() in roots
+        assert configured_extra.resolve() in roots
+        assert cli_extra.resolve() in roots
+
+    def test_resolve_discovery_roots_deduplicates(self, tmp_path) -> None:
+        extra = tmp_path / "Dup"
+        extra.mkdir()
+
+        roots = resolve_discovery_roots(extra_roots=[str(extra), str(extra)])
+
+        assert roots.count(extra.resolve()) == 1
+
+
+class TestTopLevelAndNestedDiscovery:
+    def test_top_level_app_is_discovered(self, tmp_path, app_bundle_factory) -> None:
+        app_bundle_factory(tmp_path, "Firefox")
+
+        records = discover_applications(roots=[tmp_path])
+
+        assert len(records) == 1
+        assert records[0].name == "Firefox"
+        assert records[0].parent_bundle_path is None
+
+    def test_app_in_explicit_subdirectory_is_discovered(self, tmp_path, app_bundle_factory) -> None:
+        suite_dir = tmp_path / "Python 3.12"
+        app_bundle_factory(suite_dir, "IDLE")
+
+        records = discover_applications(roots=[tmp_path])
+
+        assert len(records) == 1
+        assert records[0].name == "IDLE"
+        assert records[0].parent_bundle_path is None
+
+    def test_nested_helper_excluded_by_default(self, tmp_path, app_bundle_factory) -> None:
+        main_app = app_bundle_factory(tmp_path, "MainApp")
+        app_bundle_factory(main_app / "Contents" / "MacOS", "Helper")
+
+        records = discover_applications(roots=[tmp_path])
+
+        assert {r.name for r in records} == {"MainApp"}
+
+    def test_nested_helper_included_with_flag(self, tmp_path, app_bundle_factory) -> None:
+        main_app = app_bundle_factory(tmp_path, "MainApp")
+        app_bundle_factory(main_app / "Contents" / "MacOS", "Helper")
+
+        records = discover_applications(roots=[tmp_path], include_nested=True)
+
+        by_name = {r.name: r for r in records}
+        assert set(by_name) == {"MainApp", "Helper"}
+        assert by_name["MainApp"].parent_bundle_path is None
+        assert by_name["Helper"].parent_bundle_path == main_app.resolve()
+        assert by_name["Helper"].is_nested_component is True
+
+
+class TestPathScoping:
+    def test_app_outside_all_roots_excluded(self, tmp_path, app_bundle_factory) -> None:
+        outside = tmp_path / "outside"
+        app_bundle_factory(outside, "Ghost")
+        inside = tmp_path / "inside"
+        inside.mkdir()
+
+        records = discover_applications(roots=[inside])
+
+        assert records == []
+
+    def test_configured_additional_app_dir_is_scanned(self, tmp_path, app_bundle_factory, monkeypatch) -> None:
+        extra = tmp_path / "Extra"
+        app_bundle_factory(extra, "SideloadedApp")
+        get_config().set("additional_app_dirs", [str(extra)])
+        monkeypatch.setattr(discovery, "default_discovery_roots", lambda: [])
+
+        records = discover_applications()
+
+        assert [r.name for r in records] == ["SideloadedApp"]
+
+    def test_extra_roots_param_is_scanned(self, tmp_path, app_bundle_factory, monkeypatch) -> None:
+        extra = tmp_path / "CliDir"
+        app_bundle_factory(extra, "CliApp")
+        monkeypatch.setattr(discovery, "default_discovery_roots", lambda: [])
+
+        records = discover_applications(extra_roots=[str(extra)])
+
+        assert [r.name for r in records] == ["CliApp"]
+
+    def test_home_applications_style_root_is_scanned(self, tmp_path, app_bundle_factory, monkeypatch) -> None:
+        fake_home_apps = tmp_path / "home" / "Applications"
+        app_bundle_factory(fake_home_apps, "HomeApp")
+        monkeypatch.setattr(discovery, "default_discovery_roots", lambda: [fake_home_apps])
+
+        records = discover_applications()
+
+        assert [r.name for r in records] == ["HomeApp"]
+
+    def test_nonexistent_root_is_skipped_without_error(self, tmp_path) -> None:
+        missing = tmp_path / "DoesNotExist"
+
+        records = discover_applications(roots=[missing])
+
+        assert records == []
+
+
+class TestDeduplication:
+    def test_same_display_name_different_bundle_id_stay_distinct(self, tmp_path, app_bundle_factory) -> None:
+        app_bundle_factory(tmp_path / "A", "Editor", bundle_id="com.vendor.editor.stable")
+        app_bundle_factory(tmp_path / "B", "Editor", bundle_id="com.vendor.editor.beta")
+
+        records = discover_applications(roots=[tmp_path])
+
+        assert len(records) == 2
+        assert {r.bundle_id for r in records} == {"com.vendor.editor.stable", "com.vendor.editor.beta"}
+
+    def test_identical_bundle_seen_twice_collapses_to_one(self, tmp_path, app_bundle_factory) -> None:
+        app_bundle_factory(tmp_path, "Firefox", bundle_id="org.mozilla.firefox")
+
+        records = discover_applications(roots=[tmp_path, tmp_path])
+
+        assert len(records) == 1
+
+
+class TestAppStoreEvidenceResolution:
+    def test_mac_app_store_with_receipt_is_high_confidence(
+        self, tmp_path, app_bundle_factory, sp_entry_factory, sp_data_factory
+    ) -> None:
+        bundle = app_bundle_factory(tmp_path, "StoreApp", has_mas_receipt=True)
+        sp = sp_data_factory(sp_entry_factory(bundle, obtained_from="mac_app_store"))
+
+        records = discover_applications(roots=[tmp_path], system_profiler_data=sp)
+
+        evidence = records[0].app_store
+        assert evidence.status == AppStoreStatus.APP_STORE
+        assert evidence.confidence == EvidenceConfidence.HIGH
+
+    def test_ios_app_store_with_receipt_is_app_store(
+        self, tmp_path, app_bundle_factory, sp_entry_factory, sp_data_factory
+    ) -> None:
+        bundle = app_bundle_factory(tmp_path, "IOSApp", has_mas_receipt=True)
+        sp = sp_data_factory(sp_entry_factory(bundle, obtained_from="ios_app_store"))
+
+        records = discover_applications(roots=[tmp_path], system_profiler_data=sp)
+
+        assert records[0].app_store.status == AppStoreStatus.APP_STORE
+
+    def test_apple_obtained_from_without_receipt_is_not_app_store(
+        self, tmp_path, app_bundle_factory, sp_entry_factory, sp_data_factory
+    ) -> None:
+        bundle = app_bundle_factory(tmp_path, "AppleUtility", has_mas_receipt=False)
+        sp = sp_data_factory(sp_entry_factory(bundle, obtained_from="apple"))
+
+        records = discover_applications(roots=[tmp_path], system_profiler_data=sp)
+
+        evidence = records[0].app_store
+        assert evidence.status == AppStoreStatus.NOT_APP_STORE
+        assert evidence.confidence == EvidenceConfidence.HIGH
+
+    def test_receipt_present_overrides_conflicting_obtained_from(
+        self, tmp_path, app_bundle_factory, sp_entry_factory, sp_data_factory
+    ) -> None:
+        bundle = app_bundle_factory(tmp_path, "Weird", has_mas_receipt=True)
+        sp = sp_data_factory(sp_entry_factory(bundle, obtained_from="identified_developer"))
+
+        records = discover_applications(roots=[tmp_path], system_profiler_data=sp)
+
+        evidence = records[0].app_store
+        assert evidence.status == AppStoreStatus.APP_STORE
+        assert evidence.confidence == EvidenceConfidence.MEDIUM
+
+    def test_missing_obtained_from_resolved_from_receipt_alone(self, tmp_path, app_bundle_factory) -> None:
+        app_bundle_factory(tmp_path, "NoMetadata", has_mas_receipt=True)
+
+        records = discover_applications(roots=[tmp_path])
+
+        evidence = records[0].app_store
+        assert evidence.status == AppStoreStatus.APP_STORE
+        assert evidence.confidence == EvidenceConfidence.MEDIUM
+
+    def test_no_signals_at_all_is_not_app_store_medium_confidence(self, tmp_path, app_bundle_factory) -> None:
+        app_bundle_factory(tmp_path, "PlainApp", has_mas_receipt=False)
+
+        records = discover_applications(roots=[tmp_path])
+
+        evidence = records[0].app_store
+        assert evidence.status == AppStoreStatus.NOT_APP_STORE
+        assert evidence.confidence == EvidenceConfidence.MEDIUM
+
+    def test_app_store_apps_are_still_returned_not_dropped(
+        self, tmp_path, app_bundle_factory, sp_entry_factory, sp_data_factory
+    ) -> None:
+        bundle = app_bundle_factory(tmp_path, "StoreApp", has_mas_receipt=True)
+        sp = sp_data_factory(sp_entry_factory(bundle, obtained_from="mac_app_store"))
+
+        records = discover_applications(roots=[tmp_path], system_profiler_data=sp)
+
+        assert len(records) == 1
+        assert records[0].app_store.status == AppStoreStatus.APP_STORE
+
+    def test_mac_app_store_without_receipt_is_medium_confidence(
+        self, tmp_path, app_bundle_factory, sp_entry_factory, sp_data_factory
+    ) -> None:
+        bundle = app_bundle_factory(tmp_path, "StaleReceiptApp", has_mas_receipt=False)
+        sp = sp_data_factory(sp_entry_factory(bundle, obtained_from="mac_app_store"))
+
+        records = discover_applications(roots=[tmp_path], system_profiler_data=sp)
+
+        evidence = records[0].app_store
+        assert evidence.status == AppStoreStatus.APP_STORE
+        assert evidence.confidence == EvidenceConfidence.MEDIUM
+
+    def test_receipt_probe_failure_yields_unknown(self, tmp_path, app_bundle_factory, monkeypatch) -> None:
+        bundle = app_bundle_factory(tmp_path, "Locked", has_mas_receipt=True)
+
+        def raise_os_error(self: Path, *args: object, **kwargs: object) -> bool:
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "exists", raise_os_error)
+
+        evidence = resolve_app_store_evidence(bundle, "apple")
+
+        assert evidence.status == AppStoreStatus.UNKNOWN
+        assert evidence.confidence == EvidenceConfidence.NONE
+        assert evidence.error is not None
+
+
+class TestMalformedEntries:
+    def test_missing_info_plist_kept_with_diagnostics(self, tmp_path, app_bundle_factory) -> None:
+        app_bundle_factory(tmp_path, "Broken", write_plist=False)
+
+        records = discover_applications(roots=[tmp_path])
+
+        assert len(records) == 1
+        record = records[0]
+        assert record.name == "Broken"  # falls back to the bundle's filename stem
+        assert "missing or empty version" in record.diagnostics
+        assert "missing bundle identifier" in record.diagnostics
+
+    def test_info_plist_read_failure_returns_empty_and_does_not_raise(
+        self, tmp_path, app_bundle_factory, monkeypatch
+    ) -> None:
+        bundle = app_bundle_factory(tmp_path, "Locked")
+
+        def raise_permission_error(self: Path, *args: object, **kwargs: object) -> object:
+            raise PermissionError("denied")
+
+        monkeypatch.setattr(Path, "open", raise_permission_error)
+
+        result = discovery._read_info_plist(bundle)
+
+        assert result == {}
+
+    def test_malformed_xml_plist_returns_empty_and_does_not_raise(self, tmp_path, app_bundle_factory) -> None:
+        """Regression: confirmed live on a real machine that a genuinely
+        corrupt plist raises xml.parsers.expat.ExpatError via plistlib's XML
+        parser -- distinct from (and not caught by) OSError/ValueError/
+        plistlib.InvalidFileException."""
+        bundle = app_bundle_factory(tmp_path, "Corrupt", write_plist=False)
+        contents = bundle / "Contents"
+        contents.mkdir(parents=True, exist_ok=True)
+        (contents / "Info.plist").write_text(
+            "<?xml version='1.0'?><plist><dict><key>Foo</key><not-closed></plist>", encoding="utf-8"
+        )
+
+        result = discovery._read_info_plist(bundle)
+
+        assert result == {}
+
+
+class TestEnrichmentPriority:
+    def test_system_profiler_name_and_version_take_priority_over_info_plist(
+        self, tmp_path, app_bundle_factory, sp_entry_factory, sp_data_factory
+    ) -> None:
+        bundle = app_bundle_factory(tmp_path, "PlistName", version="1.0")
+        sp = sp_data_factory(sp_entry_factory(bundle, name="SystemProfilerName", version="2.0"))
+
+        records = discover_applications(roots=[tmp_path], system_profiler_data=sp)
+
+        assert records[0].name == "SystemProfilerName"
+        assert records[0].version == "2.0"
+
+    def test_bundle_id_from_system_profiler_entry_is_used(
+        self, tmp_path, app_bundle_factory, sp_entry_factory, sp_data_factory
+    ) -> None:
+        bundle = app_bundle_factory(tmp_path, "Editor", bundle_id="com.example.plist-id")
+        sp = sp_data_factory(sp_entry_factory(bundle, bundle_id="com.example.sp-id"))
+
+        records = discover_applications(roots=[tmp_path], system_profiler_data=sp)
+
+        assert records[0].bundle_id == "com.example.sp-id"
+
+    def test_cfbundleversion_used_when_short_version_string_missing(self, tmp_path) -> None:
+        bundle_path = tmp_path / "LegacyApp.app"
+        contents = bundle_path / "Contents"
+        contents.mkdir(parents=True)
+        with (contents / "Info.plist").open("wb") as f:
+            plistlib.dump({"CFBundleName": "LegacyApp", "CFBundleVersion": "42"}, f)
+
+        records = discover_applications(roots=[tmp_path])
+
+        assert records[0].version == "42"
+
+
+class TestPlaceholderEvidenceOnRecords:
+    def test_discovered_record_has_not_evaluated_placeholders(self, tmp_path, app_bundle_factory) -> None:
+        app_bundle_factory(tmp_path, "Firefox")
+
+        records = discover_applications(roots=[tmp_path])
+
+        record = records[0]
+        assert record.homebrew.status == HomebrewStatus.NOT_EVALUATED
+        assert record.auto_update.status == AutoUpdateStatus.NOT_EVALUATED
+        assert record.blocklist.status == BlocklistStatus.NOT_EVALUATED
+
+
+class TestNoLegacyRegressions:
+    def test_testapp_prefixed_name_is_not_rewritten(self, tmp_path, app_bundle_factory) -> None:
+        app_bundle_factory(tmp_path, "TestApp123", bundle_id="com.example.testapp123")
+
+        records = discover_applications(roots=[tmp_path])
+
+        assert records[0].name == "TestApp123"
+
+    def test_digits_in_name_are_preserved(self, tmp_path, app_bundle_factory) -> None:
+        app_bundle_factory(tmp_path, "Python 3.12", bundle_id="org.python.python312")
+
+        records = discover_applications(roots=[tmp_path])
+
+        assert records[0].name == "Python 3.12"
+
+
+class TestInternalHelpers:
+    """Direct tests for small private helpers whose defensive branches are
+    impractical to trigger through a full discover_applications() run."""
+
+    def test_nearest_parent_bundle_returns_none_for_unrelated_path(self, tmp_path) -> None:
+        unrelated = Path("/some/unrelated/tree/App.app")
+
+        assert discovery._nearest_parent_bundle(unrelated, tmp_path) is None
+
+    def test_log_walk_error_does_not_raise(self) -> None:
+        discovery._log_walk_error(OSError("simulated permission error"))

--- a/tests/audit/test_golden_fixture.py
+++ b/tests/audit/test_golden_fixture.py
@@ -1,0 +1,168 @@
+"""End-to-end golden fixture for versiontracker.audit (Phase 5).
+
+Phases 1-4's own test files each prove one resolver's truth table in
+isolation (with every other axis stubbed to NOT_EVALUATED/mocked away).
+Nothing until now has proven the *composition*: one real `run_audit()` call,
+over real on-disk bundles, exercising every resolver together and asserting
+on the final classification -- the actual thing a user experiences. This is
+the project's own "Required Test Matrix" made executable, plus one isolated
+test for its most important exit criterion: a resolver failure must never
+silently present as a negative signal.
+"""
+
+from __future__ import annotations
+
+import json
+
+import versiontracker.audit.homebrew as homebrew_module
+from versiontracker.audit.models import (
+    AuditBucket,
+    AutoUpdateStatus,
+    BlocklistMatchKind,
+    HomebrewStatus,
+)
+from versiontracker.audit.service import run_audit
+
+
+class TestGoldenFixtureCompleteIntersection:
+    """One tmp_path, one run_audit() call, seven apps -- each landing in its
+    bucket via a distinct signal (or combination of signals), proving the
+    resolvers compose correctly rather than merely existing in isolation."""
+
+    def test_complete_intersection(
+        self,
+        monkeypatch,
+        tmp_path,
+        app_bundle_factory,
+        cask_factory,
+        installed_casks_payload_factory,
+        sparkle_framework_factory,
+    ) -> None:
+        # -- App Store: a real MASReceipt is enough on its own (Phase 1's
+        # receipt-presence signal), no system_profiler enrichment needed.
+        app_bundle_factory(tmp_path, "AppStoreApp", bundle_id="com.example.appstoreapp", has_mas_receipt=True)
+
+        # -- Homebrew: cask artifact target matches this bundle's own path exactly.
+        homebrew_bundle = app_bundle_factory(tmp_path, "HomebrewManagedApp", bundle_id="com.example.homebrewmanagedapp")
+
+        # -- Auto-update: Sparkle framework + an explicit enabled preference.
+        sparkle_bundle = app_bundle_factory(
+            tmp_path,
+            "SparkleEnabledApp",
+            bundle_id="com.example.sparkleenabledapp",
+            extra_plist_keys={"SUEnableAutomaticChecks": True},
+        )
+        sparkle_framework_factory(sparkle_bundle)
+
+        # -- Blocklist: matched by display name (the weakest tier) -- no
+        # path/bundle-id/cask-token entry given, so this exercises exactly
+        # that fallback tier.
+        app_bundle_factory(tmp_path, "BlocklistedApp", bundle_id="com.example.blocklistedapp")
+
+        # -- Multiple simultaneous positive signals: Homebrew-managed *and*
+        # Sparkle present with no preference key set (unset -> CAPABLE, not
+        # ENABLED). `why` must name both, not just whichever was checked first.
+        multi_bundle = app_bundle_factory(tmp_path, "MultiSignalApp", bundle_id="com.example.multisignalapp")
+        sparkle_framework_factory(multi_bundle)
+
+        # -- All four signals quiet: the actual default "needs attention" case.
+        app_bundle_factory(tmp_path, "PlainAttentionApp", bundle_id="com.example.plainattentionapp")
+
+        # -- A cask exists and even looks related by name, but its artifact
+        # target points somewhere else -- this app was installed manually,
+        # not by that cask. HomebrewStatus.AVAILABLE is never produced by any
+        # resolver today (cask availability is a deliberately deferred later
+        # enrichment -- see versiontracker/audit/homebrew.py's own module
+        # docstring), so the honest current assertion is NOT_AVAILABLE, not
+        # the spec's aspirational "available" remediation status.
+        app_bundle_factory(tmp_path, "CaskInstalledButManualApp", bundle_id="com.example.caskinstalledbutmanualapp")
+
+        payload = installed_casks_payload_factory(
+            cask_factory("homebrewmanagedapp", app_name="HomebrewManagedApp.app", app_target=str(homebrew_bundle)),
+            cask_factory("multisignalapp", app_name="MultiSignalApp.app", app_target=str(multi_bundle)),
+            cask_factory(
+                "caskinstalledbutmanualapp",
+                app_name="CaskInstalledButManualApp.app",
+                app_target=str(tmp_path / "SomeOtherLocation" / "CaskInstalledButManualApp.app"),
+            ),
+        )
+        monkeypatch.setattr(homebrew_module, "run_command_secure", lambda *a, **k: (json.dumps(payload), 0))
+        monkeypatch.setattr(homebrew_module, "get_brew_command", lambda: "/opt/homebrew/bin/brew")
+        empty_launch_agent_dir = tmp_path / "EmptyLaunchAgents"
+        empty_launch_agent_dir.mkdir()
+
+        result = run_audit(
+            roots=[tmp_path],
+            system_profiler_data={"SPApplicationsDataType": []},
+            launch_agent_dirs=[empty_launch_agent_dir],
+            blocklist_entries=["BlocklistedApp"],
+        )
+
+        expected_buckets = {
+            "AppStoreApp": AuditBucket.MANAGED,
+            "HomebrewManagedApp": AuditBucket.MANAGED,
+            "SparkleEnabledApp": AuditBucket.MANAGED,
+            "BlocklistedApp": AuditBucket.MANAGED,
+            "MultiSignalApp": AuditBucket.MANAGED,
+            "PlainAttentionApp": AuditBucket.ATTENTION,
+            "CaskInstalledButManualApp": AuditBucket.ATTENTION,
+        }
+        by_name = {a.record.name: a for a in result.applications}
+        assert set(by_name) == set(expected_buckets)
+        for name, expected in expected_buckets.items():
+            app = by_name[name]
+            assert app.classification.bucket == expected, (
+                f"{name}: expected {expected}, got {app.classification.bucket} ({app.classification.why})"
+            )
+
+        # Summary is derived from the same table it's checked against, not a
+        # separately hand-maintained literal, so it can't silently drift
+        # when a row is added later.
+        expected_summary = {"total": len(expected_buckets), "unknown": 0}
+        for bucket in (AuditBucket.ATTENTION, AuditBucket.MANAGED):
+            expected_summary[bucket.value] = sum(1 for b in expected_buckets.values() if b == bucket)
+        assert result.summary == expected_summary
+
+        # Per-axis spot checks: each app must reach its bucket via the
+        # *intended* signal, not coincidentally.
+        assert by_name["AppStoreApp"].record.app_store.status.value == "app_store"
+        assert by_name["HomebrewManagedApp"].record.homebrew.status == HomebrewStatus.MANAGED
+        assert by_name["HomebrewManagedApp"].record.homebrew.matched_identifier == "homebrewmanagedapp"
+        assert by_name["SparkleEnabledApp"].record.auto_update.status == AutoUpdateStatus.ENABLED
+        assert by_name["BlocklistedApp"].record.blocklist.matched_by == BlocklistMatchKind.DISPLAY_NAME
+        assert by_name["CaskInstalledButManualApp"].record.homebrew.status == HomebrewStatus.NOT_AVAILABLE
+
+        # MultiSignalApp: why must name *both* signals, not just one.
+        multi_why = by_name["MultiSignalApp"].classification.why
+        assert "Homebrew" in multi_why
+        assert "auto-update mechanism" in multi_why
+        assert by_name["MultiSignalApp"].record.auto_update.status == AutoUpdateStatus.CAPABLE
+
+    def test_homebrew_failure_produces_unknown_not_false_end_to_end(
+        self, monkeypatch, tmp_path, app_bundle_factory
+    ) -> None:
+        """The exit criterion stated by this project's own handoff spec:
+        'The composite test fails if any resolver silently changes unknown
+        to false.' Kept isolated from the larger matrix above so a
+        regression here has an unambiguous failure signal: this one app has
+        no auto-update artifacts and isn't blocklisted, so both of those
+        axes cleanly resolve negative on their own -- ATTENTION is exactly
+        what a silently-flipped-to-false Homebrew resolver would produce
+        instead of the correct UNKNOWN."""
+        app_bundle_factory(tmp_path, "SomeApp", bundle_id="com.example.someapp")
+        monkeypatch.setattr(homebrew_module, "run_command_secure", lambda *a, **k: ("boom", 1))
+        monkeypatch.setattr(homebrew_module, "get_brew_command", lambda: "/opt/homebrew/bin/brew")
+        empty_launch_agent_dir = tmp_path / "EmptyLaunchAgents"
+        empty_launch_agent_dir.mkdir()
+
+        result = run_audit(
+            roots=[tmp_path],
+            system_profiler_data={"SPApplicationsDataType": []},
+            launch_agent_dirs=[empty_launch_agent_dir],
+        )
+
+        assert len(result.applications) == 1
+        app = result.applications[0]
+        assert app.record.homebrew.status == HomebrewStatus.UNKNOWN
+        assert app.record.homebrew.error is not None
+        assert app.classification.bucket == AuditBucket.UNKNOWN

--- a/tests/audit/test_homebrew.py
+++ b/tests/audit/test_homebrew.py
@@ -1,0 +1,283 @@
+"""Tests for versiontracker.audit.homebrew."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import versiontracker.audit.homebrew as homebrew_module
+from versiontracker.audit.homebrew import (
+    apply_homebrew_evidence,
+    build_artifact_index,
+    fetch_installed_casks,
+    resolve_homebrew_evidence,
+)
+from versiontracker.audit.models import (
+    ApplicationRecord,
+    AppStoreEvidence,
+    AppStoreStatus,
+    EvidenceSource,
+    HomebrewStatus,
+)
+from versiontracker.exceptions import DataParsingError, HomebrewError, NetworkError
+from versiontracker.exceptions import TimeoutError as VtTimeoutError
+
+
+def _make_record(canonical_path: Path, *, bundle_id: str | None = None, name: str = "App") -> ApplicationRecord:
+    return ApplicationRecord(
+        name=name,
+        version="1.0",
+        path=canonical_path,
+        canonical_path=canonical_path,
+        bundle_id=bundle_id,
+        obtained_from=None,
+        parent_bundle_path=None,
+        app_store=AppStoreEvidence(
+            status=AppStoreStatus.NOT_APP_STORE, reason="test", source=EvidenceSource.SYSTEM_PROFILER
+        ),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _fake_brew_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every test gets a fixed, fake brew path -- no dependency on the real
+    test-running machine's actual Homebrew installation."""
+    monkeypatch.setattr(homebrew_module, "get_brew_command", lambda: "/opt/homebrew/bin/brew")
+
+
+class TestFetchInstalledCasks:
+    def test_success_returns_casks_list(self, monkeypatch, installed_casks_payload_factory, cask_factory) -> None:
+        payload = installed_casks_payload_factory(cask_factory("firefox", app_name="Firefox.app"))
+        monkeypatch.setattr(homebrew_module, "run_command_secure", lambda *a, **k: (json.dumps(payload), 0))
+
+        casks = fetch_installed_casks()
+
+        assert len(casks) == 1
+        assert casks[0]["token"] == "firefox"
+
+    def test_nonzero_returncode_raises_homebrew_error(self, monkeypatch) -> None:
+        monkeypatch.setattr(homebrew_module, "run_command_secure", lambda *a, **k: ("some error", 1))
+
+        with pytest.raises(HomebrewError):
+            fetch_installed_casks()
+
+    def test_timeout_raises_network_error(self, monkeypatch) -> None:
+        def raise_timeout(*args: object, **kwargs: object) -> tuple[str, int]:
+            raise VtTimeoutError("timed out")
+
+        monkeypatch.setattr(homebrew_module, "run_command_secure", raise_timeout)
+
+        with pytest.raises(NetworkError):
+            fetch_installed_casks()
+
+    def test_missing_brew_binary_raises_homebrew_error(self, monkeypatch) -> None:
+        """Confirmed live: run_command_secure surfaces a bare builtins.Exception
+        for a missing executable -- its own FileNotFoundError except clause is
+        bound to versiontracker's custom subclass, not the plain builtin
+        subprocess.Popen actually raises. fetch_installed_casks must still
+        degrade this to HomebrewError, not let it propagate uncaught."""
+
+        def raise_bare_exception(*args: object, **kwargs: object) -> tuple[str, int]:
+            raise Exception("[Errno 2] No such file or directory: 'brew'")
+
+        monkeypatch.setattr(homebrew_module, "run_command_secure", raise_bare_exception)
+
+        with pytest.raises(HomebrewError):
+            fetch_installed_casks()
+
+    def test_malformed_json_raises_data_parsing_error(self, monkeypatch) -> None:
+        monkeypatch.setattr(homebrew_module, "run_command_secure", lambda *a, **k: ("not json", 0))
+
+        with pytest.raises(DataParsingError):
+            fetch_installed_casks()
+
+    def test_missing_casks_key_returns_empty_list(self, monkeypatch) -> None:
+        monkeypatch.setattr(homebrew_module, "run_command_secure", lambda *a, **k: ("{}", 0))
+
+        assert fetch_installed_casks() == []
+
+
+class TestBuildArtifactIndex:
+    def test_single_app_cask_indexed_by_canonical_target(self, cask_factory) -> None:
+        casks = [
+            cask_factory("firefox", app_name="Firefox.app", app_target="/Applications/Firefox.app", installed="120.0")
+        ]
+
+        index = build_artifact_index(casks)
+
+        key = Path("/Applications/Firefox.app").resolve()
+        assert key in index
+        assert index[key].token == "firefox"
+        assert index[key].installed_version == "120.0"
+
+    def test_zero_app_artifact_cask_contributes_nothing(self, cask_factory) -> None:
+        casks = [cask_factory("font-hack-nerd-font", app_name=None)]
+
+        assert build_artifact_index(casks) == {}
+
+    def test_multi_app_cask_produces_two_separate_index_entries(self, cask_factory) -> None:
+        cask = cask_factory(
+            "caffeine-mini-pro", app_name="Caffeine Mini.app", app_target="/Applications/Caffeine Mini.app"
+        )
+        cask["artifacts"].append({"app": ["Caffeine Pro.app"], "target": "/Applications/Caffeine Pro.app"})
+
+        index = build_artifact_index([cask])
+
+        assert Path("/Applications/Caffeine Mini.app").resolve() in index
+        assert Path("/Applications/Caffeine Pro.app").resolve() in index
+        assert len(index) == 2
+
+    def test_non_app_artifacts_alongside_app_artifact_are_skipped(self, cask_factory) -> None:
+        """Real casks always mix artifact kinds (uninstall/zap/binary/preflight
+        alongside app) -- confirm non-app-keyed entries don't confuse indexing."""
+        cask = cask_factory("firefox", app_name="Firefox.app", app_target="/Applications/Firefox.app")
+        cask["artifacts"] = [
+            {"preflight": None},
+            {"uninstall": [{"quit": "org.mozilla.firefox"}]},
+            *cask["artifacts"],
+            {"binary": ["firefox"], "target": "/opt/homebrew/bin/firefox"},
+        ]
+
+        index = build_artifact_index([cask])
+
+        assert len(index) == 1
+        assert Path("/Applications/Firefox.app").resolve() in index
+
+    def test_cask_without_token_is_skipped(self, cask_factory) -> None:
+        cask = cask_factory("firefox", app_name="Firefox.app")
+        del cask["token"]
+
+        assert build_artifact_index([cask]) == {}
+
+    def test_unresolvable_target_is_skipped(self, monkeypatch, cask_factory) -> None:
+        monkeypatch.setattr(homebrew_module, "_canonicalize_target", lambda target: None)
+        casks = [cask_factory("firefox", app_name="Firefox.app", app_target="/Applications/Firefox.app")]
+
+        assert build_artifact_index(casks) == {}
+
+    def test_third_party_tap_cask_indexed_same_as_official(self, cask_factory) -> None:
+        casks = [cask_factory("container-use", tap="dagger/tap", app_name="Container Use.app")]
+
+        index = build_artifact_index(casks)
+
+        assert len(index) == 1
+        assert next(iter(index.values())).tap == "dagger/tap"
+
+    def test_canonical_path_collision_keeps_first_seen(self, cask_factory) -> None:
+        first = cask_factory("app-a", app_name="Shared.app", app_target="/Applications/Shared.app")
+        second = cask_factory("app-b", app_name="Shared.app", app_target="/Applications/Shared.app")
+
+        index = build_artifact_index([first, second])
+
+        assert len(index) == 1
+        assert next(iter(index.values())).token == "app-a"
+
+    def test_artifact_without_target_is_skipped(self, cask_factory) -> None:
+        cask = cask_factory("weird", app_name="Weird.app")
+        cask["artifacts"][0].pop("target")
+
+        assert build_artifact_index([cask]) == {}
+
+
+class TestResolveHomebrewEvidence:
+    def test_exact_match_is_managed(self, cask_factory) -> None:
+        casks = [
+            cask_factory("firefox", app_name="Firefox.app", app_target="/Applications/Firefox.app", installed="120.0")
+        ]
+        index = build_artifact_index(casks)
+        record = _make_record(Path("/Applications/Firefox.app").resolve())
+
+        evidence = resolve_homebrew_evidence(record, index)
+
+        assert evidence.status == HomebrewStatus.MANAGED
+        assert evidence.matched_identifier == "firefox"
+        assert evidence.installed_version == "120.0"
+        assert evidence.artifact_target == Path("/Applications/Firefox.app").resolve()
+
+    def test_cask_auto_updates_true_is_threaded_through(self, cask_factory) -> None:
+        casks = [
+            cask_factory("firefox", app_name="Firefox.app", app_target="/Applications/Firefox.app", auto_updates=True)
+        ]
+        index = build_artifact_index(casks)
+        record = _make_record(Path("/Applications/Firefox.app").resolve())
+
+        evidence = resolve_homebrew_evidence(record, index)
+
+        assert evidence.cask_auto_updates is True
+
+    def test_cask_auto_updates_false_is_threaded_through(self, cask_factory) -> None:
+        casks = [
+            cask_factory("firefox", app_name="Firefox.app", app_target="/Applications/Firefox.app", auto_updates=False)
+        ]
+        index = build_artifact_index(casks)
+        record = _make_record(Path("/Applications/Firefox.app").resolve())
+
+        evidence = resolve_homebrew_evidence(record, index)
+
+        assert evidence.cask_auto_updates is False
+
+    def test_no_match_cask_auto_updates_stays_none(self, cask_factory) -> None:
+        casks = [cask_factory("firefox", app_name="Firefox.app", app_target="/Applications/Firefox.app")]
+        index = build_artifact_index(casks)
+        record = _make_record(Path("/Applications/ManuallyInstalled.app").resolve())
+
+        evidence = resolve_homebrew_evidence(record, index)
+
+        assert evidence.cask_auto_updates is None
+
+    def test_no_match_is_not_available(self, cask_factory) -> None:
+        casks = [cask_factory("firefox", app_name="Firefox.app", app_target="/Applications/Firefox.app")]
+        index = build_artifact_index(casks)
+        record = _make_record(Path("/Applications/ManuallyInstalled.app").resolve())
+
+        evidence = resolve_homebrew_evidence(record, index)
+
+        assert evidence.status == HomebrewStatus.NOT_AVAILABLE
+
+    def test_empty_index_is_not_available(self) -> None:
+        record = _make_record(Path("/Applications/Anything.app").resolve())
+
+        evidence = resolve_homebrew_evidence(record, {})
+
+        assert evidence.status == HomebrewStatus.NOT_AVAILABLE
+
+
+class TestApplyHomebrewEvidence:
+    def test_success_attaches_resolved_evidence_per_record(
+        self, monkeypatch, installed_casks_payload_factory, cask_factory
+    ) -> None:
+        payload = installed_casks_payload_factory(
+            cask_factory("firefox", app_name="Firefox.app", app_target="/Applications/Firefox.app")
+        )
+        monkeypatch.setattr(homebrew_module, "run_command_secure", lambda *a, **k: (json.dumps(payload), 0))
+        managed_record = _make_record(Path("/Applications/Firefox.app").resolve(), name="Firefox")
+        unmanaged_record = _make_record(Path("/Applications/Manual.app").resolve(), name="Manual")
+
+        result = apply_homebrew_evidence([managed_record, unmanaged_record])
+
+        by_name = {r.name: r for r in result}
+        assert by_name["Firefox"].homebrew.status == HomebrewStatus.MANAGED
+        assert by_name["Manual"].homebrew.status == HomebrewStatus.NOT_AVAILABLE
+
+    def test_fetch_failure_degrades_every_record_to_unknown(self, monkeypatch) -> None:
+        """Exit criterion 3: Homebrew failure produces unknown, never not_managed."""
+        monkeypatch.setattr(homebrew_module, "run_command_secure", lambda *a, **k: ("boom", 1))
+        records = [
+            _make_record(Path("/Applications/A.app").resolve()),
+            _make_record(Path("/Applications/B.app").resolve()),
+        ]
+
+        result = apply_homebrew_evidence(records)
+
+        assert all(r.homebrew.status == HomebrewStatus.UNKNOWN for r in result)
+        assert all(r.homebrew.error is not None for r in result)
+
+    def test_original_records_are_not_mutated(self, monkeypatch) -> None:
+        monkeypatch.setattr(homebrew_module, "run_command_secure", lambda *a, **k: ('{"casks": []}', 0))
+        record = _make_record(Path("/Applications/A.app").resolve())
+
+        apply_homebrew_evidence([record])
+
+        assert record.homebrew.status == HomebrewStatus.NOT_EVALUATED

--- a/tests/audit/test_models.py
+++ b/tests/audit/test_models.py
@@ -1,0 +1,293 @@
+"""Tests for versiontracker.audit.models."""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from versiontracker.audit.models import (
+    ApplicationRecord,
+    AppStoreEvidence,
+    AppStoreStatus,
+    AutoUpdateEvidence,
+    AutoUpdateMechanism,
+    AutoUpdateStatus,
+    BlocklistEvidence,
+    BlocklistMatchKind,
+    BlocklistStatus,
+    EvidenceConfidence,
+    EvidenceSource,
+    HomebrewEvidence,
+    HomebrewStatus,
+)
+
+
+def _make_app_store_evidence(status: AppStoreStatus = AppStoreStatus.NOT_APP_STORE) -> AppStoreEvidence:
+    return AppStoreEvidence(status=status, reason="test reason", source=EvidenceSource.SYSTEM_PROFILER)
+
+
+def _make_record(**overrides: object) -> ApplicationRecord:
+    defaults: dict[str, object] = {
+        "name": "Firefox",
+        "version": "120.0",
+        "path": Path("/Applications/Firefox.app"),
+        "canonical_path": Path("/Applications/Firefox.app"),
+        "bundle_id": "org.mozilla.firefox",
+        "obtained_from": "identified_developer",
+        "parent_bundle_path": None,
+        "app_store": _make_app_store_evidence(),
+    }
+    defaults.update(overrides)
+    return ApplicationRecord(**defaults)  # type: ignore[arg-type]
+
+
+class TestFrozenness:
+    def test_application_record_is_frozen(self) -> None:
+        record = _make_record()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            record.name = "Chrome"  # type: ignore[misc]
+
+    def test_app_store_evidence_is_frozen(self) -> None:
+        evidence = _make_app_store_evidence()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            evidence.status = AppStoreStatus.APP_STORE  # type: ignore[misc]
+
+    def test_homebrew_evidence_is_frozen(self) -> None:
+        evidence = HomebrewEvidence.not_evaluated()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            evidence.status = HomebrewStatus.MANAGED  # type: ignore[misc]
+
+    def test_auto_update_evidence_is_frozen(self) -> None:
+        evidence = AutoUpdateEvidence.not_evaluated()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            evidence.status = AutoUpdateStatus.ENABLED  # type: ignore[misc]
+
+    def test_blocklist_evidence_is_frozen(self) -> None:
+        evidence = BlocklistEvidence.not_evaluated()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            evidence.status = BlocklistStatus.BLOCKED  # type: ignore[misc]
+
+    def test_homebrew_evidence_new_fields_are_frozen(self) -> None:
+        evidence = HomebrewEvidence.not_evaluated()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            evidence.installed_version = "1.0"  # type: ignore[misc]
+
+    def test_blocklist_evidence_matched_by_is_frozen(self) -> None:
+        evidence = BlocklistEvidence.not_evaluated()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            evidence.matched_by = BlocklistMatchKind.DISPLAY_NAME  # type: ignore[misc]
+
+    def test_homebrew_evidence_cask_auto_updates_is_frozen(self) -> None:
+        evidence = HomebrewEvidence.not_evaluated()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            evidence.cask_auto_updates = True  # type: ignore[misc]
+
+    def test_auto_update_evidence_mechanisms_is_frozen(self) -> None:
+        evidence = AutoUpdateEvidence.not_evaluated()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            evidence.mechanisms = (AutoUpdateMechanism.SPARKLE_FRAMEWORK,)  # type: ignore[misc]
+
+
+class TestPlaceholderDefaults:
+    def test_homebrew_defaults_to_not_evaluated(self) -> None:
+        record = _make_record()
+        assert record.homebrew.status == HomebrewStatus.NOT_EVALUATED
+        assert record.homebrew.source == EvidenceSource.NOT_EVALUATED
+        assert record.homebrew.confidence == EvidenceConfidence.NONE
+
+    def test_auto_update_defaults_to_not_evaluated(self) -> None:
+        record = _make_record()
+        assert record.auto_update.status == AutoUpdateStatus.NOT_EVALUATED
+        assert record.auto_update.source == EvidenceSource.NOT_EVALUATED
+        assert record.auto_update.confidence == EvidenceConfidence.NONE
+
+    def test_blocklist_defaults_to_not_evaluated(self) -> None:
+        record = _make_record()
+        assert record.blocklist.status == BlocklistStatus.NOT_EVALUATED
+        assert record.blocklist.source == EvidenceSource.NOT_EVALUATED
+        assert record.blocklist.confidence == EvidenceConfidence.NONE
+
+    def test_app_store_has_no_default(self) -> None:
+        with pytest.raises(TypeError):
+            ApplicationRecord(  # type: ignore[call-arg]
+                name="Firefox",
+                version="120.0",
+                path=Path("/Applications/Firefox.app"),
+                canonical_path=Path("/Applications/Firefox.app"),
+                bundle_id=None,
+                obtained_from=None,
+                parent_bundle_path=None,
+            )
+
+    def test_diagnostics_defaults_to_empty_tuple(self) -> None:
+        record = _make_record()
+        assert record.diagnostics == ()
+
+
+class TestNotEvaluatedFactories:
+    def test_homebrew_not_evaluated(self) -> None:
+        evidence = HomebrewEvidence.not_evaluated()
+        assert evidence.status is HomebrewStatus.NOT_EVALUATED
+        assert evidence.source is EvidenceSource.NOT_EVALUATED
+
+    def test_auto_update_not_evaluated(self) -> None:
+        evidence = AutoUpdateEvidence.not_evaluated()
+        assert evidence.status is AutoUpdateStatus.NOT_EVALUATED
+        assert evidence.source is EvidenceSource.NOT_EVALUATED
+
+    def test_blocklist_not_evaluated(self) -> None:
+        evidence = BlocklistEvidence.not_evaluated()
+        assert evidence.status is BlocklistStatus.NOT_EVALUATED
+        assert evidence.source is EvidenceSource.NOT_EVALUATED
+
+
+class TestPhase2Fields:
+    """New Phase 2 fields on HomebrewEvidence/BlocklistEvidence."""
+
+    def test_homebrew_evidence_new_fields_default_to_none(self) -> None:
+        evidence = HomebrewEvidence.not_evaluated()
+        assert evidence.installed_version is None
+        assert evidence.artifact_target is None
+
+    def test_homebrew_evidence_new_fields_can_be_populated(self) -> None:
+        evidence = HomebrewEvidence(
+            status=HomebrewStatus.MANAGED,
+            reason="test reason",
+            source=EvidenceSource.HOMEBREW_CLI,
+            matched_identifier="firefox",
+            installed_version="120.0",
+            artifact_target=Path("/Applications/Firefox.app"),
+        )
+        assert evidence.installed_version == "120.0"
+        assert evidence.artifact_target == Path("/Applications/Firefox.app")
+
+    def test_blocklist_evidence_matched_by_defaults_to_none(self) -> None:
+        evidence = BlocklistEvidence.not_evaluated()
+        assert evidence.matched_by is None
+
+    def test_blocklist_evidence_matched_by_can_be_populated(self) -> None:
+        evidence = BlocklistEvidence(
+            status=BlocklistStatus.BLOCKED,
+            reason="test reason",
+            source=EvidenceSource.CONFIG,
+            matched_identifier="Little Snitch",
+            matched_by=BlocklistMatchKind.DISPLAY_NAME,
+        )
+        assert evidence.matched_by is BlocklistMatchKind.DISPLAY_NAME
+
+
+class TestPhase3Fields:
+    """New Phase 3 fields on HomebrewEvidence/AutoUpdateEvidence."""
+
+    def test_homebrew_evidence_cask_auto_updates_defaults_to_none(self) -> None:
+        evidence = HomebrewEvidence.not_evaluated()
+        assert evidence.cask_auto_updates is None
+
+    def test_homebrew_evidence_cask_auto_updates_can_be_populated(self) -> None:
+        evidence = HomebrewEvidence(
+            status=HomebrewStatus.MANAGED,
+            reason="test reason",
+            source=EvidenceSource.HOMEBREW_CLI,
+            cask_auto_updates=True,
+        )
+        assert evidence.cask_auto_updates is True
+
+    def test_auto_update_evidence_mechanisms_defaults_to_empty_tuple(self) -> None:
+        evidence = AutoUpdateEvidence.not_evaluated()
+        assert evidence.mechanisms == ()
+
+    def test_auto_update_evidence_mechanisms_can_be_populated(self) -> None:
+        evidence = AutoUpdateEvidence(
+            status=AutoUpdateStatus.CAPABLE,
+            reason="test reason",
+            source=EvidenceSource.FILESYSTEM,
+            mechanisms=(AutoUpdateMechanism.SPARKLE_FRAMEWORK, AutoUpdateMechanism.ELECTRON_UPDATER_YML),
+        )
+        assert evidence.mechanisms == (
+            AutoUpdateMechanism.SPARKLE_FRAMEWORK,
+            AutoUpdateMechanism.ELECTRON_UPDATER_YML,
+        )
+
+
+class TestIdentityAndEquality:
+    def test_identity_key_matches_canonical_path_and_bundle_id(self) -> None:
+        record = _make_record(bundle_id="org.mozilla.firefox")
+        assert record.identity_key == (record.canonical_path, "org.mozilla.firefox")
+
+    def test_equal_records_are_equal_and_hashable(self) -> None:
+        record_a = _make_record()
+        record_b = _make_record()
+        assert record_a == record_b
+        assert hash(record_a) == hash(record_b)
+        assert len({record_a, record_b}) == 1
+
+    def test_records_with_different_bundle_ids_are_not_equal(self) -> None:
+        record_a = _make_record(bundle_id="org.mozilla.firefox")
+        record_b = _make_record(bundle_id="org.mozilla.firefox.beta")
+        assert record_a != record_b
+
+    def test_is_nested_component_false_when_no_parent(self) -> None:
+        record = _make_record(parent_bundle_path=None)
+        assert record.is_nested_component is False
+
+    def test_is_nested_component_true_when_parent_set(self) -> None:
+        record = _make_record(parent_bundle_path=Path("/Applications/Suite.app"))
+        assert record.is_nested_component is True
+
+
+class TestEnumValueStability:
+    """Pins literal enum string values -- guards the future JSON export contract."""
+
+    def test_app_store_status_values(self) -> None:
+        assert AppStoreStatus.APP_STORE.value == "app_store"
+        assert AppStoreStatus.NOT_APP_STORE.value == "not_app_store"
+        assert AppStoreStatus.UNKNOWN.value == "unknown"
+
+    def test_homebrew_status_values(self) -> None:
+        assert HomebrewStatus.MANAGED.value == "managed"
+        assert HomebrewStatus.AVAILABLE.value == "available"
+        assert HomebrewStatus.NOT_AVAILABLE.value == "not_available"
+        assert HomebrewStatus.UNKNOWN.value == "unknown"
+        assert HomebrewStatus.NOT_EVALUATED.value == "not_evaluated"
+
+    def test_auto_update_status_values(self) -> None:
+        assert AutoUpdateStatus.ENABLED.value == "enabled"
+        assert AutoUpdateStatus.CAPABLE.value == "capable"
+        assert AutoUpdateStatus.NONE_DETECTED.value == "none_detected"
+        assert AutoUpdateStatus.UNKNOWN.value == "unknown"
+        assert AutoUpdateStatus.NOT_EVALUATED.value == "not_evaluated"
+
+    def test_blocklist_status_values(self) -> None:
+        assert BlocklistStatus.BLOCKED.value == "blocked"
+        assert BlocklistStatus.NOT_BLOCKED.value == "not_blocked"
+        assert BlocklistStatus.UNKNOWN.value == "unknown"
+        assert BlocklistStatus.NOT_EVALUATED.value == "not_evaluated"
+
+    def test_blocklist_match_kind_values(self) -> None:
+        assert BlocklistMatchKind.CANONICAL_PATH.value == "canonical_path"
+        assert BlocklistMatchKind.BUNDLE_ID.value == "bundle_id"
+        assert BlocklistMatchKind.HOMEBREW_TOKEN.value == "homebrew_token"
+        assert BlocklistMatchKind.DISPLAY_NAME.value == "display_name"
+
+    def test_auto_update_mechanism_values(self) -> None:
+        assert AutoUpdateMechanism.SPARKLE_FRAMEWORK.value == "sparkle_framework"
+        assert AutoUpdateMechanism.SQUIRREL_FRAMEWORK.value == "squirrel_framework"
+        assert AutoUpdateMechanism.ELECTRON_UPDATER_YML.value == "electron_updater_yml"
+        assert AutoUpdateMechanism.MOZILLA_UPDATER.value == "mozilla_updater"
+        assert AutoUpdateMechanism.VENDOR_LAUNCH_AGENT.value == "vendor_launch_agent"
+        assert AutoUpdateMechanism.HOMEBREW_CASK_AUTO_UPDATES.value == "homebrew_cask_auto_updates"
+
+    def test_evidence_source_values(self) -> None:
+        assert EvidenceSource.SYSTEM_PROFILER.value == "system_profiler"
+        assert EvidenceSource.FILESYSTEM.value == "filesystem"
+        assert EvidenceSource.HOMEBREW_CLI.value == "homebrew_cli"
+        assert EvidenceSource.CONFIG.value == "config"
+        assert EvidenceSource.NOT_EVALUATED.value == "not_evaluated"
+
+    def test_evidence_confidence_values(self) -> None:
+        assert EvidenceConfidence.HIGH.value == "high"
+        assert EvidenceConfidence.MEDIUM.value == "medium"
+        assert EvidenceConfidence.LOW.value == "low"
+        assert EvidenceConfidence.NONE.value == "none"

--- a/tests/audit/test_rendering.py
+++ b/tests/audit/test_rendering.py
@@ -1,0 +1,242 @@
+"""Tests for versiontracker.audit.rendering."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from pathlib import Path
+
+import yaml
+
+from versiontracker.audit.models import (
+    ApplicationRecord,
+    AppStoreEvidence,
+    AppStoreStatus,
+    AuditBucket,
+    AuditClassification,
+    AuditResult,
+    AutoUpdateEvidence,
+    AutoUpdateMechanism,
+    AutoUpdateStatus,
+    BlocklistEvidence,
+    BlocklistMatchKind,
+    BlocklistStatus,
+    ClassifiedApplication,
+    EvidenceSource,
+    HomebrewEvidence,
+    HomebrewStatus,
+)
+from versiontracker.audit.rendering import render_csv, render_json, render_terminal, render_yaml
+
+
+def _record(
+    *,
+    name: str = "Firefox",
+    canonical_path: Path | None = None,
+    bundle_id: str | None = "org.mozilla.firefox",
+    app_store_status: AppStoreStatus = AppStoreStatus.NOT_APP_STORE,
+    homebrew_status: HomebrewStatus = HomebrewStatus.NOT_AVAILABLE,
+    auto_update_status: AutoUpdateStatus = AutoUpdateStatus.NONE_DETECTED,
+    blocklist_status: BlocklistStatus = BlocklistStatus.NOT_BLOCKED,
+) -> ApplicationRecord:
+    path = canonical_path if canonical_path is not None else Path(f"/Applications/{name}.app")
+    return ApplicationRecord(
+        name=name,
+        version="120.0",
+        path=path,
+        canonical_path=path,
+        bundle_id=bundle_id,
+        obtained_from=None,
+        parent_bundle_path=None,
+        app_store=AppStoreEvidence(
+            status=app_store_status, reason="app store reason", source=EvidenceSource.SYSTEM_PROFILER
+        ),
+        homebrew=HomebrewEvidence(
+            status=homebrew_status,
+            reason="homebrew reason",
+            source=EvidenceSource.HOMEBREW_CLI,
+            matched_identifier="firefox" if homebrew_status == HomebrewStatus.MANAGED else None,
+        ),
+        auto_update=AutoUpdateEvidence(
+            status=auto_update_status,
+            reason="auto-update reason",
+            source=EvidenceSource.FILESYSTEM,
+            mechanisms=(AutoUpdateMechanism.SPARKLE_FRAMEWORK,)
+            if auto_update_status != AutoUpdateStatus.NONE_DETECTED
+            else (),
+        ),
+        blocklist=BlocklistEvidence(
+            status=blocklist_status,
+            reason="blocklist reason",
+            source=EvidenceSource.CONFIG,
+            matched_by=BlocklistMatchKind.DISPLAY_NAME if blocklist_status == BlocklistStatus.BLOCKED else None,
+        ),
+    )
+
+
+def _classified(record: ApplicationRecord, bucket: AuditBucket, why: str = "test why") -> ClassifiedApplication:
+    return ClassifiedApplication(record=record, classification=AuditClassification(bucket=bucket, why=why))
+
+
+def _result(*classified_apps: ClassifiedApplication) -> AuditResult:
+    summary = {"total": len(classified_apps), "attention": 0, "unknown": 0, "managed": 0}
+    for app in classified_apps:
+        summary[app.classification.bucket.value] += 1
+    return AuditResult(applications=tuple(classified_apps), summary=summary)
+
+
+class TestRenderTerminal:
+    def test_compact_table_shows_expected_columns(self) -> None:
+        result = _result(_classified(_record(), AuditBucket.ATTENTION))
+
+        output = render_terminal(result, explain=False)
+
+        assert "Needs manual management" in output
+        assert "Firefox" in output
+        assert "120.0" in output
+        assert "Summary" in output
+
+    def test_explain_shows_full_evidence_per_axis(self) -> None:
+        result = _result(_classified(_record(), AuditBucket.ATTENTION))
+
+        output = render_terminal(result, explain=True)
+
+        assert "app store reason" in output
+        assert "homebrew reason" in output
+        assert "auto-update reason" in output
+        assert "blocklist reason" in output
+        assert "source=" in output
+        assert "confidence=" in output
+
+    def test_unknown_section_shown_when_present(self) -> None:
+        result = _result(_classified(_record(name="Unknown App"), AuditBucket.UNKNOWN))
+
+        output = render_terminal(result, explain=False)
+
+        assert "Needs review (unknown evidence)" in output
+        assert "Needs manual management" not in output
+
+    def test_managed_section_absent_when_not_in_result(self) -> None:
+        """render_terminal only groups what it's given -- excluding managed
+        apps from the default view is filter_result's job (see
+        TestFilterResult in test_service.py), not render_terminal's; this
+        just confirms no stray "Managed" section header leaks in when there
+        are no managed apps in the (already-filtered) input."""
+        result = _result(_classified(_record(name="Attention App"), AuditBucket.ATTENTION))
+
+        output = render_terminal(result, explain=False)
+
+        assert "Needs manual management" in output
+        assert "Managed\n" not in output
+
+    def test_managed_section_shown_when_present(self) -> None:
+        """A regression test for a real bug: `--status managed` (show_all=False,
+        status=MANAGED) filters `result.applications` down to managed apps
+        only, so render_terminal must show them even though show_all=False
+        -- gating on show_all here previously produced an empty list."""
+        result = _result(_classified(_record(name="Managed App"), AuditBucket.MANAGED))
+
+        output = render_terminal(result, explain=False)
+
+        assert "Managed App" in output
+
+    def test_summary_always_present_even_when_empty(self) -> None:
+        output = render_terminal(_result(), explain=False)
+
+        assert "Summary" in output
+
+
+class TestRenderJson:
+    def test_schema_and_summary(self) -> None:
+        result = _result(_classified(_record(), AuditBucket.ATTENTION))
+
+        parsed = json.loads(render_json(result))
+
+        assert parsed["schema_version"] == 1
+        assert parsed["summary"] == result.summary
+        assert len(parsed["applications"]) == 1
+
+    def test_full_evidence_present(self) -> None:
+        result = _result(_classified(_record(homebrew_status=HomebrewStatus.MANAGED), AuditBucket.MANAGED))
+
+        app_dict = json.loads(render_json(result))["applications"][0]
+
+        assert app_dict["app_store"]["status"] == "not_app_store"
+        assert app_dict["homebrew"]["status"] == "managed"
+        assert app_dict["homebrew"]["matched_identifier"] == "firefox"
+        assert app_dict["classification"] == "managed"
+        assert "why" in app_dict
+
+    def test_path_and_none_serialize_correctly(self) -> None:
+        result = _result(_classified(_record(canonical_path=Path("/Applications/Firefox.app")), AuditBucket.ATTENTION))
+
+        app_dict = json.loads(render_json(result))["applications"][0]
+
+        assert app_dict["canonical_path"] == "/Applications/Firefox.app"
+        assert app_dict["obtained_from"] is None
+        assert app_dict["parent_bundle_path"] is None
+
+    def test_tuple_fields_serialize_as_lists(self) -> None:
+        result = _result(_classified(_record(auto_update_status=AutoUpdateStatus.CAPABLE), AuditBucket.MANAGED))
+
+        app_dict = json.loads(render_json(result))["applications"][0]
+
+        assert app_dict["auto_update"]["mechanisms"] == ["sparkle_framework"]
+        assert isinstance(app_dict["diagnostics"], list)
+
+
+class TestRenderYaml:
+    def test_round_trips_and_matches_json_shape(self) -> None:
+        result = _result(_classified(_record(), AuditBucket.ATTENTION))
+
+        assert yaml.safe_load(render_yaml(result)) == json.loads(render_json(result))
+
+    def test_schema_version_is_first_key(self) -> None:
+        result = _result(_classified(_record(), AuditBucket.ATTENTION))
+
+        assert render_yaml(result).strip().startswith("schema_version:")
+
+
+class TestRenderCsv:
+    def test_header_and_row_count(self) -> None:
+        result = _result(
+            _classified(_record(name="App1"), AuditBucket.ATTENTION),
+            _classified(_record(name="App2"), AuditBucket.MANAGED),
+        )
+
+        rows = list(csv.DictReader(io.StringIO(render_csv(result))))
+
+        assert len(rows) == 2
+        assert rows[0]["name"] == "App1"
+
+    def test_empty_result_produces_header_only(self) -> None:
+        output = render_csv(_result())
+
+        rows = list(csv.DictReader(io.StringIO(output)))
+
+        assert rows == []
+        assert "name" in output
+        assert "app_store_status" in output
+
+    def test_evidence_fields_flattened_with_prefix(self) -> None:
+        result = _result(_classified(_record(homebrew_status=HomebrewStatus.MANAGED), AuditBucket.MANAGED))
+
+        rows = list(csv.DictReader(io.StringIO(render_csv(result))))
+
+        assert rows[0]["homebrew_status"] == "managed"
+        assert rows[0]["homebrew_matched_identifier"] == "firefox"
+
+    def test_none_values_become_empty_string(self) -> None:
+        result = _result(_classified(_record(), AuditBucket.ATTENTION))
+
+        rows = list(csv.DictReader(io.StringIO(render_csv(result))))
+
+        assert rows[0]["obtained_from"] == ""
+
+    def test_list_values_semicolon_joined(self) -> None:
+        result = _result(_classified(_record(auto_update_status=AutoUpdateStatus.CAPABLE), AuditBucket.MANAGED))
+
+        rows = list(csv.DictReader(io.StringIO(render_csv(result))))
+
+        assert rows[0]["auto_update_mechanisms"] == "sparkle_framework"

--- a/tests/audit/test_service.py
+++ b/tests/audit/test_service.py
@@ -1,0 +1,383 @@
+"""Tests for versiontracker.audit.service."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import versiontracker.audit.homebrew as homebrew_module
+import versiontracker.audit.service as service_module
+from versiontracker.audit.models import (
+    ApplicationRecord,
+    AppStoreEvidence,
+    AppStoreStatus,
+    AuditBucket,
+    AuditClassification,
+    AuditResult,
+    AutoUpdateEvidence,
+    AutoUpdateStatus,
+    BlocklistEvidence,
+    BlocklistMatchKind,
+    BlocklistStatus,
+    ClassifiedApplication,
+    EvidenceSource,
+    HomebrewEvidence,
+    HomebrewStatus,
+)
+from versiontracker.audit.service import classify_record, filter_result, run_audit
+
+
+def _app_store(status: AppStoreStatus = AppStoreStatus.NOT_APP_STORE, error: str | None = None) -> AppStoreEvidence:
+    return AppStoreEvidence(status=status, reason="test", source=EvidenceSource.SYSTEM_PROFILER, error=error)
+
+
+def _homebrew(
+    status: HomebrewStatus = HomebrewStatus.NOT_AVAILABLE,
+    token: str | None = None,
+    reason: str = "test",
+    error: str | None = None,
+) -> HomebrewEvidence:
+    return HomebrewEvidence(
+        status=status, reason=reason, source=EvidenceSource.HOMEBREW_CLI, matched_identifier=token, error=error
+    )
+
+
+def _auto_update(
+    status: AutoUpdateStatus = AutoUpdateStatus.NONE_DETECTED, error: str | None = None
+) -> AutoUpdateEvidence:
+    return AutoUpdateEvidence(status=status, reason="test", source=EvidenceSource.FILESYSTEM, error=error)
+
+
+def _blocklist(
+    status: BlocklistStatus = BlocklistStatus.NOT_BLOCKED,
+    matched_by: BlocklistMatchKind | None = None,
+    error: str | None = None,
+) -> BlocklistEvidence:
+    return BlocklistEvidence(
+        status=status, reason="test", source=EvidenceSource.CONFIG, matched_by=matched_by, error=error
+    )
+
+
+def _make_record(
+    *,
+    name: str = "App",
+    canonical_path: Path = Path("/Applications/App.app"),
+    app_store: AppStoreEvidence | None = None,
+    homebrew: HomebrewEvidence | None = None,
+    auto_update: AutoUpdateEvidence | None = None,
+    blocklist: BlocklistEvidence | None = None,
+) -> ApplicationRecord:
+    return ApplicationRecord(
+        name=name,
+        version="1.0",
+        path=canonical_path,
+        canonical_path=canonical_path,
+        bundle_id=None,
+        obtained_from=None,
+        parent_bundle_path=None,
+        app_store=app_store if app_store is not None else _app_store(),
+        homebrew=homebrew if homebrew is not None else _homebrew(),
+        auto_update=auto_update if auto_update is not None else _auto_update(),
+        blocklist=blocklist if blocklist is not None else _blocklist(),
+    )
+
+
+class TestClassifyRecordAttention:
+    def test_all_quiet_is_attention(self) -> None:
+        classification = classify_record(_make_record())
+
+        assert classification.bucket == AuditBucket.ATTENTION
+
+    def test_homebrew_available_stays_attention_eligible(self) -> None:
+        """Regression: the classification bug caught during design review --
+        only MANAGED should exclude from attention, not "!= NOT_AVAILABLE",
+        which would have wrongly excluded a future AVAILABLE result."""
+        record = _make_record(homebrew=_homebrew(status=HomebrewStatus.AVAILABLE, reason="cask 'foo' available"))
+
+        classification = classify_record(record)
+
+        assert classification.bucket == AuditBucket.ATTENTION
+        assert "remediation suggestion" in classification.why
+
+
+class TestClassifyRecordManaged:
+    def test_app_store_managed(self) -> None:
+        record = _make_record(app_store=_app_store(status=AppStoreStatus.APP_STORE))
+
+        classification = classify_record(record)
+
+        assert classification.bucket == AuditBucket.MANAGED
+        assert "App Store" in classification.why
+
+    def test_homebrew_managed(self) -> None:
+        record = _make_record(homebrew=_homebrew(status=HomebrewStatus.MANAGED, token="firefox"))
+
+        classification = classify_record(record)
+
+        assert classification.bucket == AuditBucket.MANAGED
+        assert "firefox" in classification.why
+
+    def test_auto_update_enabled(self) -> None:
+        classification = classify_record(_make_record(auto_update=_auto_update(status=AutoUpdateStatus.ENABLED)))
+
+        assert classification.bucket == AuditBucket.MANAGED
+
+    def test_auto_update_capable(self) -> None:
+        classification = classify_record(_make_record(auto_update=_auto_update(status=AutoUpdateStatus.CAPABLE)))
+
+        assert classification.bucket == AuditBucket.MANAGED
+
+    def test_blocklisted(self) -> None:
+        record = _make_record(
+            blocklist=_blocklist(status=BlocklistStatus.BLOCKED, matched_by=BlocklistMatchKind.DISPLAY_NAME)
+        )
+
+        classification = classify_record(record)
+
+        assert classification.bucket == AuditBucket.MANAGED
+        assert "blocklisted" in classification.why.lower()
+
+
+class TestClassifyRecordUnknown:
+    def test_app_store_unknown(self) -> None:
+        record = _make_record(app_store=_app_store(status=AppStoreStatus.UNKNOWN, error="probe failed"))
+
+        classification = classify_record(record)
+
+        assert classification.bucket == AuditBucket.UNKNOWN
+        assert "app_store" in classification.why
+        assert "probe failed" in classification.why
+
+    def test_homebrew_unknown(self) -> None:
+        record = _make_record(homebrew=_homebrew(status=HomebrewStatus.UNKNOWN, error="brew missing"))
+
+        assert classify_record(record).bucket == AuditBucket.UNKNOWN
+
+    def test_auto_update_unknown(self) -> None:
+        record = _make_record(auto_update=_auto_update(status=AutoUpdateStatus.UNKNOWN, error="permission denied"))
+
+        assert classify_record(record).bucket == AuditBucket.UNKNOWN
+
+    def test_blocklist_unknown(self) -> None:
+        record = _make_record(blocklist=_blocklist(status=BlocklistStatus.UNKNOWN, error="config malformed"))
+
+        assert classify_record(record).bucket == AuditBucket.UNKNOWN
+
+    def test_not_evaluated_treated_as_unknown(self) -> None:
+        record = _make_record(auto_update=AutoUpdateEvidence.not_evaluated())
+
+        assert classify_record(record).bucket == AuditBucket.UNKNOWN
+
+    def test_blocked_plus_different_axis_unknown_is_unknown_not_managed(self) -> None:
+        """Precedence case surfaced during design review: an unconditional
+        UNKNOWN axis must win even alongside a confident BLOCKED elsewhere.
+        The blocklist match itself is never lost -- it's still on
+        record.blocklist regardless of which bucket the record lands in."""
+        record = _make_record(
+            blocklist=_blocklist(status=BlocklistStatus.BLOCKED, matched_by=BlocklistMatchKind.BUNDLE_ID),
+            auto_update=_auto_update(status=AutoUpdateStatus.UNKNOWN, error="permission denied"),
+        )
+
+        classification = classify_record(record)
+
+        assert classification.bucket == AuditBucket.UNKNOWN
+        assert record.blocklist.status == BlocklistStatus.BLOCKED
+
+
+class TestFetchSystemProfilerData:
+    def test_success_returns_data(self, monkeypatch) -> None:
+        monkeypatch.setattr(service_module, "get_json_data", lambda cmd: {"SPApplicationsDataType": []})
+
+        assert service_module._fetch_system_profiler_data() == {"SPApplicationsDataType": []}
+
+    def test_failure_degrades_to_none(self, monkeypatch) -> None:
+        def raise_error(cmd: str) -> None:
+            raise Exception("simulated failure")
+
+        monkeypatch.setattr(service_module, "get_json_data", raise_error)
+
+        assert service_module._fetch_system_profiler_data() is None
+
+
+class TestRunAuditOrchestration:
+    def _patch_pipeline(self, monkeypatch, call_order: list[str]) -> None:
+        def fake_discover(**kwargs: object) -> list[ApplicationRecord]:
+            call_order.append("discover")
+            return []
+
+        def fake_homebrew(records: list[ApplicationRecord]) -> list[ApplicationRecord]:
+            call_order.append("homebrew")
+            return records
+
+        def fake_blocklist(
+            records: list[ApplicationRecord], blocklist_entries: object = None
+        ) -> list[ApplicationRecord]:
+            call_order.append("blocklist")
+            return records
+
+        def fake_auto_update(
+            records: list[ApplicationRecord], launch_agent_dirs: object = None
+        ) -> list[ApplicationRecord]:
+            call_order.append("auto_update")
+            return records
+
+        monkeypatch.setattr(service_module, "discover_applications", fake_discover)
+        monkeypatch.setattr(service_module, "apply_homebrew_evidence", fake_homebrew)
+        monkeypatch.setattr(service_module, "apply_blocklist_evidence", fake_blocklist)
+        monkeypatch.setattr(service_module, "apply_auto_update_evidence", fake_auto_update)
+
+    def test_calls_resolvers_in_correct_order(self, monkeypatch) -> None:
+        """Homebrew must resolve before BOTH blocklist and auto-update."""
+        call_order: list[str] = []
+        self._patch_pipeline(monkeypatch, call_order)
+        monkeypatch.setattr(service_module, "_fetch_system_profiler_data", lambda: None)
+
+        run_audit()
+
+        assert call_order[0] == "discover"
+        assert call_order.index("homebrew") < call_order.index("blocklist")
+        assert call_order.index("homebrew") < call_order.index("auto_update")
+
+    def test_explicit_system_profiler_data_skips_fetch(self, monkeypatch) -> None:
+        call_order: list[str] = []
+        self._patch_pipeline(monkeypatch, call_order)
+        fetch_called = []
+        monkeypatch.setattr(service_module, "_fetch_system_profiler_data", lambda: fetch_called.append(True))
+
+        run_audit(system_profiler_data={"SPApplicationsDataType": []})
+
+        assert fetch_called == []
+
+    def test_none_system_profiler_data_triggers_fetch(self, monkeypatch) -> None:
+        call_order: list[str] = []
+        self._patch_pipeline(monkeypatch, call_order)
+        fetch_called = []
+
+        def fake_fetch() -> None:
+            fetch_called.append(True)
+            return None
+
+        monkeypatch.setattr(service_module, "_fetch_system_profiler_data", fake_fetch)
+
+        run_audit()
+
+        assert fetch_called == [True]
+
+    def test_summary_counts_match_classifications(self, monkeypatch) -> None:
+        records = [
+            _make_record(name="Attention", canonical_path=Path("/Applications/Attention.app")),
+            _make_record(
+                name="Managed",
+                canonical_path=Path("/Applications/Managed.app"),
+                app_store=_app_store(status=AppStoreStatus.APP_STORE),
+            ),
+            _make_record(
+                name="Unknown",
+                canonical_path=Path("/Applications/Unknown.app"),
+                app_store=_app_store(status=AppStoreStatus.UNKNOWN, error="probe failed"),
+            ),
+        ]
+        monkeypatch.setattr(service_module, "discover_applications", lambda **kwargs: records)
+        monkeypatch.setattr(service_module, "apply_homebrew_evidence", lambda r: r)
+        monkeypatch.setattr(service_module, "apply_blocklist_evidence", lambda r, blocklist_entries=None: r)
+        monkeypatch.setattr(service_module, "apply_auto_update_evidence", lambda r, launch_agent_dirs=None: r)
+        monkeypatch.setattr(service_module, "_fetch_system_profiler_data", lambda: None)
+
+        result = run_audit()
+
+        assert result.summary == {"total": 3, "attention": 1, "managed": 1, "unknown": 1}
+        assert len(result.applications) == 3
+
+
+class TestPipelineOrderIntegration:
+    """Real on-disk bundles, real discover_applications()/apply_blocklist_evidence()/
+    apply_auto_update_evidence() -- only fetch_installed_casks is mocked.
+    These prove the load-bearing pipeline order end-to-end, not just that
+    the resolver functions are *called* in order."""
+
+    def test_homebrew_auto_updates_supplement_requires_homebrew_first(
+        self, monkeypatch, tmp_path, app_bundle_factory, cask_factory, installed_casks_payload_factory
+    ) -> None:
+        bundle = app_bundle_factory(tmp_path, "ManagedApp")
+        payload = installed_casks_payload_factory(
+            cask_factory("managedapp", app_name="ManagedApp.app", app_target=str(bundle), auto_updates=True)
+        )
+        monkeypatch.setattr(homebrew_module, "run_command_secure", lambda *a, **k: (json.dumps(payload), 0))
+        monkeypatch.setattr(homebrew_module, "get_brew_command", lambda: "/opt/homebrew/bin/brew")
+        empty_launch_agent_dir = tmp_path / "EmptyLaunchAgents"
+        empty_launch_agent_dir.mkdir()
+
+        result = run_audit(
+            roots=[tmp_path],
+            system_profiler_data={"SPApplicationsDataType": []},
+            launch_agent_dirs=[empty_launch_agent_dir],
+        )
+
+        app = next(a for a in result.applications if a.record.name == "ManagedApp")
+        assert app.record.homebrew.status == HomebrewStatus.MANAGED
+        assert app.record.auto_update.status == AutoUpdateStatus.CAPABLE
+
+    def test_blocklist_by_homebrew_token_requires_homebrew_first(
+        self, monkeypatch, tmp_path, app_bundle_factory, cask_factory, installed_casks_payload_factory
+    ) -> None:
+        bundle = app_bundle_factory(tmp_path, "BlockedApp")
+        payload = installed_casks_payload_factory(
+            cask_factory("blockedapp", app_name="BlockedApp.app", app_target=str(bundle))
+        )
+        monkeypatch.setattr(homebrew_module, "run_command_secure", lambda *a, **k: (json.dumps(payload), 0))
+        monkeypatch.setattr(homebrew_module, "get_brew_command", lambda: "/opt/homebrew/bin/brew")
+        empty_launch_agent_dir = tmp_path / "EmptyLaunchAgents"
+        empty_launch_agent_dir.mkdir()
+
+        result = run_audit(
+            roots=[tmp_path],
+            system_profiler_data={"SPApplicationsDataType": []},
+            launch_agent_dirs=[empty_launch_agent_dir],
+            blocklist_entries=["blockedapp"],
+        )
+
+        app = next(a for a in result.applications if a.record.name == "BlockedApp")
+        assert app.record.homebrew.status == HomebrewStatus.MANAGED
+        assert app.record.blocklist.status == BlocklistStatus.BLOCKED
+
+
+class TestFilterResult:
+    def _make_result(self) -> AuditResult:
+        attention_app = ClassifiedApplication(
+            record=_make_record(name="Attention"),
+            classification=AuditClassification(bucket=AuditBucket.ATTENTION, why="test"),
+        )
+        unknown_app = ClassifiedApplication(
+            record=_make_record(name="Unknown"),
+            classification=AuditClassification(bucket=AuditBucket.UNKNOWN, why="test"),
+        )
+        managed_app = ClassifiedApplication(
+            record=_make_record(name="Managed"),
+            classification=AuditClassification(bucket=AuditBucket.MANAGED, why="test"),
+        )
+        summary = {"total": 3, "attention": 1, "unknown": 1, "managed": 1}
+        return AuditResult(applications=(attention_app, unknown_app, managed_app), summary=summary)
+
+    def test_default_shows_attention_and_unknown_only(self) -> None:
+        result = self._make_result()
+
+        filtered = filter_result(result, show_all=False, status=None)
+
+        assert {app.record.name for app in filtered.applications} == {"Attention", "Unknown"}
+        assert filtered.summary == result.summary
+
+    def test_all_shows_everything(self) -> None:
+        result = self._make_result()
+
+        filtered = filter_result(result, show_all=True, status=None)
+
+        assert len(filtered.applications) == 3
+        assert filtered.summary == result.summary
+
+    def test_status_filters_to_exactly_one_bucket(self) -> None:
+        result = self._make_result()
+
+        filtered = filter_result(result, show_all=False, status=AuditBucket.MANAGED)
+
+        assert {app.record.name for app in filtered.applications} == {"Managed"}
+        assert filtered.summary == result.summary

--- a/tests/handlers/test_audit_handlers.py
+++ b/tests/handlers/test_audit_handlers.py
@@ -1,0 +1,233 @@
+"""Tests for versiontracker.handlers.audit_handlers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+import versiontracker.handlers.audit_handlers as audit_handlers_module
+from versiontracker.audit.models import (
+    ApplicationRecord,
+    AppStoreEvidence,
+    AppStoreStatus,
+    AuditBucket,
+    AuditClassification,
+    AuditResult,
+    AutoUpdateEvidence,
+    AutoUpdateStatus,
+    BlocklistEvidence,
+    BlocklistStatus,
+    ClassifiedApplication,
+    EvidenceSource,
+    HomebrewEvidence,
+    HomebrewStatus,
+)
+from versiontracker.handlers.audit_handlers import handle_audit
+
+
+def _make_options(**overrides: object) -> Mock:
+    options = Mock()
+    options.additional_dirs = None
+    options.blocklist = None
+    options.blacklist = None
+    options.all = False
+    options.status = None
+    options.explain = False
+    options.export_format = None
+    options.output_file = None
+    for key, value in overrides.items():
+        setattr(options, key, value)
+    return options
+
+
+def _make_result(bucket: AuditBucket = AuditBucket.ATTENTION) -> AuditResult:
+    path = Path("/Applications/Firefox.app")
+    record = ApplicationRecord(
+        name="Firefox",
+        version="120.0",
+        path=path,
+        canonical_path=path,
+        bundle_id="org.mozilla.firefox",
+        obtained_from=None,
+        parent_bundle_path=None,
+        app_store=AppStoreEvidence(
+            status=AppStoreStatus.NOT_APP_STORE, reason="test", source=EvidenceSource.SYSTEM_PROFILER
+        ),
+        homebrew=HomebrewEvidence(
+            status=HomebrewStatus.NOT_AVAILABLE, reason="test", source=EvidenceSource.HOMEBREW_CLI
+        ),
+        auto_update=AutoUpdateEvidence(
+            status=AutoUpdateStatus.NONE_DETECTED, reason="test", source=EvidenceSource.FILESYSTEM
+        ),
+        blocklist=BlocklistEvidence(status=BlocklistStatus.NOT_BLOCKED, reason="test", source=EvidenceSource.CONFIG),
+    )
+    app = ClassifiedApplication(record=record, classification=AuditClassification(bucket=bucket, why="test why"))
+    summary = {"total": 1, "attention": 0, "unknown": 0, "managed": 0}
+    summary[bucket.value] = 1
+    return AuditResult(applications=(app,), summary=summary)
+
+
+class TestHandleAuditTerminalOutput:
+    def test_default_prints_terminal_sections(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(audit_handlers_module, "run_audit", lambda **kwargs: _make_result())
+
+        exit_code = handle_audit(_make_options())
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "Needs manual management" in captured.out
+        assert "Firefox" in captured.out
+
+
+class TestHandleAuditExport:
+    def test_export_json_prints_only_json(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(audit_handlers_module, "run_audit", lambda **kwargs: _make_result())
+
+        exit_code = handle_audit(_make_options(export_format="json"))
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)  # raises if anything else was printed alongside it
+        assert parsed["schema_version"] == 1
+
+    def test_export_with_output_file_writes_file_and_prints_confirmation_only(
+        self, monkeypatch, capsys, tmp_path
+    ) -> None:
+        monkeypatch.setattr(audit_handlers_module, "run_audit", lambda **kwargs: _make_result())
+        output_file = tmp_path / "audit.json"
+
+        exit_code = handle_audit(_make_options(export_format="json", output_file=str(output_file)))
+
+        assert exit_code == 0
+        assert output_file.exists()
+        content = json.loads(output_file.read_text())
+        assert content["schema_version"] == 1
+        captured = capsys.readouterr()
+        assert "Exported" in captured.out
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(captured.out)  # a confirmation line, not the export content itself
+
+    def test_export_output_file_write_failure_returns_error(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.setattr(audit_handlers_module, "run_audit", lambda **kwargs: _make_result())
+        unwritable_path = tmp_path / "does-not-exist" / "audit.json"
+
+        exit_code = handle_audit(_make_options(export_format="json", output_file=str(unwritable_path)))
+
+        assert exit_code == 1
+        assert not unwritable_path.exists()
+
+    def test_export_unsupported_format_returns_error(self, monkeypatch) -> None:
+        monkeypatch.setattr(audit_handlers_module, "run_audit", lambda **kwargs: _make_result())
+
+        exit_code = handle_audit(_make_options(export_format="xml"))
+
+        assert exit_code == 1
+
+    def test_export_yaml_and_csv_also_work(self, monkeypatch) -> None:
+        monkeypatch.setattr(audit_handlers_module, "run_audit", lambda **kwargs: _make_result())
+
+        assert handle_audit(_make_options(export_format="yaml")) == 0
+        assert handle_audit(_make_options(export_format="csv")) == 0
+
+
+class TestAdditionalDirsParsing:
+    def test_colon_separated_dirs_passed_as_extra_roots(self, monkeypatch) -> None:
+        captured_kwargs: dict[str, Any] = {}
+
+        def fake_run_audit(**kwargs: Any) -> AuditResult:
+            captured_kwargs.update(kwargs)
+            return _make_result()
+
+        monkeypatch.setattr(audit_handlers_module, "run_audit", fake_run_audit)
+
+        handle_audit(_make_options(additional_dirs="/path/one:/path/two"))
+
+        assert captured_kwargs["extra_roots"] == ["/path/one", "/path/two"]
+
+    def test_no_additional_dirs_is_none(self, monkeypatch) -> None:
+        captured_kwargs: dict[str, Any] = {}
+
+        def fake_run_audit(**kwargs: object) -> AuditResult:
+            captured_kwargs.update(kwargs)
+            return _make_result()
+
+        monkeypatch.setattr(audit_handlers_module, "run_audit", fake_run_audit)
+
+        handle_audit(_make_options())
+
+        assert captured_kwargs["extra_roots"] is None
+
+
+class TestBlocklistMerging:
+    def test_config_and_cli_blocklist_both_apply(self, monkeypatch) -> None:
+        """Merge, not override -- per the spec's explicit merge-semantics
+        requirement for an audit filter."""
+        mock_config = Mock()
+        mock_config.get_blocklist.return_value = ["Little Snitch"]
+        monkeypatch.setattr(audit_handlers_module, "get_config", lambda: mock_config)
+        captured_kwargs: dict[str, Any] = {}
+
+        def fake_run_audit(**kwargs: object) -> AuditResult:
+            captured_kwargs.update(kwargs)
+            return _make_result()
+
+        monkeypatch.setattr(audit_handlers_module, "run_audit", fake_run_audit)
+
+        handle_audit(_make_options(blocklist="Visual Studio Code,Firefox"))
+
+        entries = captured_kwargs["blocklist_entries"]
+        assert "Little Snitch" in entries
+        assert "Visual Studio Code" in entries
+        assert "Firefox" in entries
+
+    def test_deduplicates_entries(self, monkeypatch) -> None:
+        mock_config = Mock()
+        mock_config.get_blocklist.return_value = ["Firefox"]
+        monkeypatch.setattr(audit_handlers_module, "get_config", lambda: mock_config)
+        captured_kwargs: dict[str, Any] = {}
+
+        def fake_run_audit(**kwargs: object) -> AuditResult:
+            captured_kwargs.update(kwargs)
+            return _make_result()
+
+        monkeypatch.setattr(audit_handlers_module, "run_audit", fake_run_audit)
+
+        handle_audit(_make_options(blocklist="Firefox"))
+
+        assert captured_kwargs["blocklist_entries"].count("Firefox") == 1
+
+
+class TestStatusAndAllFiltering:
+    def test_status_option_converted_to_audit_bucket(self, monkeypatch) -> None:
+        captured_kwargs: dict[str, Any] = {}
+
+        def fake_filter_result(result: AuditResult, **kwargs: object) -> AuditResult:
+            captured_kwargs.update(kwargs)
+            return result
+
+        monkeypatch.setattr(audit_handlers_module, "run_audit", lambda **kwargs: _make_result())
+        monkeypatch.setattr(audit_handlers_module, "filter_result", fake_filter_result)
+
+        handle_audit(_make_options(status="managed"))
+
+        assert captured_kwargs["status"] == AuditBucket.MANAGED
+        assert captured_kwargs["show_all"] is False
+
+    def test_all_option_passed_through(self, monkeypatch) -> None:
+        captured_kwargs: dict[str, Any] = {}
+
+        def fake_filter_result(result: AuditResult, **kwargs: object) -> AuditResult:
+            captured_kwargs.update(kwargs)
+            return result
+
+        monkeypatch.setattr(audit_handlers_module, "run_audit", lambda **kwargs: _make_result())
+        monkeypatch.setattr(audit_handlers_module, "filter_result", fake_filter_result)
+
+        handle_audit(_make_options(all=True))
+
+        assert captured_kwargs["show_all"] is True
+        assert captured_kwargs["status"] is None

--- a/tests/handlers/test_macos_handlers.py
+++ b/tests/handlers/test_macos_handlers.py
@@ -53,7 +53,7 @@ class TestHandleInstallService:
     @patch("sys.platform", "darwin")
     def test_custom_interval(self, mock_install, _pb):
         handle_install_service(Namespace(service_interval=12))
-        mock_install.assert_called_once_with(12, ["--outdated", "--no-progress"])
+        mock_install.assert_called_once_with(12, ["--check-outdated", "--no-progress"])
 
     @patch("versiontracker.handlers.macos_handlers.create_progress_bar", return_value=_mock_progress_bar())
     @patch(

--- a/tests/integration/test_cli_workflows.py
+++ b/tests/integration/test_cli_workflows.py
@@ -6,11 +6,29 @@ Unlike the macOS-only end-to-end tests, these run in any CI environment.
 """
 
 import json
+from pathlib import Path
 from unittest import mock
 
 import pytest
 
 from versiontracker.__main__ import versiontracker_main
+from versiontracker.audit import AuditResult
+from versiontracker.audit.models import (
+    ApplicationRecord,
+    AppStoreEvidence,
+    AppStoreStatus,
+    AuditBucket,
+    AuditClassification,
+    AutoUpdateEvidence,
+    AutoUpdateStatus,
+    BlocklistEvidence,
+    BlocklistStatus,
+    ClassifiedApplication,
+    EvidenceSource,
+    HomebrewEvidence,
+    HomebrewStatus,
+)
+from versiontracker.deprecation import reset_deprecation_registry
 
 _FAKE_APPS = [
     ("Firefox", "110.0"),
@@ -19,6 +37,41 @@ _FAKE_APPS = [
 ]
 
 _FAKE_BREWS = ["firefox", "google-chrome", "visual-studio-code"]
+
+
+def _classified_app(name: str, bucket: AuditBucket) -> ClassifiedApplication:
+    path = Path(f"/Applications/{name}.app")
+    record = ApplicationRecord(
+        name=name,
+        version="1.0",
+        path=path,
+        canonical_path=path,
+        bundle_id=f"com.example.{name.lower()}",
+        obtained_from=None,
+        parent_bundle_path=None,
+        app_store=AppStoreEvidence(
+            status=AppStoreStatus.NOT_APP_STORE, reason="test", source=EvidenceSource.FILESYSTEM
+        ),
+        homebrew=HomebrewEvidence(
+            status=HomebrewStatus.NOT_AVAILABLE, reason="test", source=EvidenceSource.HOMEBREW_CLI
+        ),
+        auto_update=AutoUpdateEvidence(
+            status=AutoUpdateStatus.NONE_DETECTED, reason="test", source=EvidenceSource.FILESYSTEM
+        ),
+        blocklist=BlocklistEvidence(status=BlocklistStatus.NOT_BLOCKED, reason="test", source=EvidenceSource.CONFIG),
+    )
+    return ClassifiedApplication(record=record, classification=AuditClassification(bucket=bucket, why=f"{name} why"))
+
+
+def _three_bucket_audit_result() -> AuditResult:
+    """One app per bucket -- lets a single fixed AuditResult drive every
+    --all/--status/--explain/--export observable-output test below."""
+    applications = (
+        _classified_app("AttentionApp", AuditBucket.ATTENTION),
+        _classified_app("UnknownApp", AuditBucket.UNKNOWN),
+        _classified_app("ManagedApp", AuditBucket.MANAGED),
+    )
+    return AuditResult(applications=applications, summary={"total": 3, "attention": 1, "unknown": 1, "managed": 1})
 
 
 @pytest.fixture(autouse=True)
@@ -141,3 +194,89 @@ class TestCLIWorkflows:
         # Handler may return 0 (up-to-date) or non-zero based on display logic;
         # the important thing is it completes without raising an unhandled exception.
         assert result in (0, 1)
+
+    def test_audit_export_json_produces_clean_parseable_stdout(self, capsys):
+        """--audit --export json must print *only* the JSON, even when combined
+        with a deprecated flag -- this is the only test level that would catch a
+        regression in __main__._emit_deprecation_warnings's emit_console_hint
+        wiring, since handler-level unit tests mock straight past it."""
+        reset_deprecation_registry()
+        fake_result = AuditResult(applications=(), summary={"total": 0, "attention": 0, "unknown": 0, "managed": 0})
+        with (
+            mock.patch("versiontracker.handlers.audit_handlers.run_audit", return_value=fake_result),
+            mock.patch(
+                "sys.argv",
+                ["versiontracker", "--audit", "--export", "json", "--blacklist", "Firefox"],
+            ),
+        ):
+            result = versiontracker_main()
+
+        assert result == 0
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)  # raises if a stray [DEPRECATION] line snuck in
+        assert parsed["schema_version"] == 1
+        assert parsed["applications"] == []
+
+    def test_audit_default_view_hides_managed_app(self, capsys):
+        """Default --audit shows attention/unknown, hides the managed app --
+        the CLI-level proof that --all changes observable output at all."""
+        with (
+            mock.patch("versiontracker.handlers.audit_handlers.run_audit", return_value=_three_bucket_audit_result()),
+            mock.patch("sys.argv", ["versiontracker", "--audit"]),
+        ):
+            result = versiontracker_main()
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "AttentionApp" in captured.out
+        assert "UnknownApp" in captured.out
+        assert "ManagedApp" not in captured.out
+
+    def test_audit_all_flag_reveals_managed_app(self, capsys):
+        """--all is the one flag whose whole purpose is revealing the
+        otherwise-hidden managed app -- directly observable in stdout."""
+        with (
+            mock.patch("versiontracker.handlers.audit_handlers.run_audit", return_value=_three_bucket_audit_result()),
+            mock.patch("sys.argv", ["versiontracker", "--audit", "--all"]),
+        ):
+            result = versiontracker_main()
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "ManagedApp" in captured.out
+
+    def test_audit_status_flag_shows_only_that_bucket(self, capsys):
+        """--status managed shows only the managed app, not the other two --
+        proves --status actually filters, not just accepts the argument."""
+        with (
+            mock.patch("versiontracker.handlers.audit_handlers.run_audit", return_value=_three_bucket_audit_result()),
+            mock.patch("sys.argv", ["versiontracker", "--audit", "--status", "managed"]),
+        ):
+            result = versiontracker_main()
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "ManagedApp" in captured.out
+        assert "AttentionApp" not in captured.out
+        assert "UnknownApp" not in captured.out
+
+    def test_audit_explain_flag_shows_full_evidence(self, capsys):
+        """--explain's whole purpose is exposing per-axis evidence
+        (confidence=/source=) that the default compact table never prints."""
+        with (
+            mock.patch("versiontracker.handlers.audit_handlers.run_audit", return_value=_three_bucket_audit_result()),
+            mock.patch("sys.argv", ["versiontracker", "--audit", "--all"]),
+        ):
+            versiontracker_main()
+        compact_out = capsys.readouterr().out
+
+        with (
+            mock.patch("versiontracker.handlers.audit_handlers.run_audit", return_value=_three_bucket_audit_result()),
+            mock.patch("sys.argv", ["versiontracker", "--audit", "--all", "--explain"]),
+        ):
+            result = versiontracker_main()
+        explain_out = capsys.readouterr().out
+
+        assert result == 0
+        assert "confidence=" not in compact_out
+        assert "confidence=" in explain_out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """Tests for the CLI module."""
 
 import unittest
+from io import StringIO
 from unittest.mock import patch
 
 from versiontracker.cli import get_arguments
@@ -131,6 +132,55 @@ class TestCLI(unittest.TestCase):
             self.assertEqual(args.additional_dirs, "/path1:/path2")
             self.assertEqual(args.similarity, 80)
             self.assertTrue(args.no_progress)
+
+    def test_audit_flag(self):
+        """Test --audit flag."""
+        with patch("sys.argv", ["versiontracker", "--audit"]):
+            args = get_arguments()
+            self.assertTrue(args.audit)
+            self.assertFalse(args.apps)
+            self.assertFalse(args.all)
+            self.assertIsNone(args.status)
+            self.assertFalse(args.explain)
+
+    def test_audit_all_flag(self):
+        """Test --audit --all flag."""
+        with patch("sys.argv", ["versiontracker", "--audit", "--all"]):
+            args = get_arguments()
+            self.assertTrue(args.audit)
+            self.assertTrue(args.all)
+            self.assertIsNone(args.status)
+
+    def test_audit_explain_flag(self):
+        """Test --audit --explain flag."""
+        with patch("sys.argv", ["versiontracker", "--audit", "--explain"]):
+            args = get_arguments()
+            self.assertTrue(args.audit)
+            self.assertTrue(args.explain)
+
+    def test_audit_status_choices(self):
+        """Test --audit --status accepts only its defined choices."""
+        for status in ("attention", "unknown", "managed"):
+            with self.subTest(status=status):
+                with patch("sys.argv", ["versiontracker", "--audit", "--status", status]):
+                    args = get_arguments()
+                    self.assertEqual(args.status, status)
+
+        with patch("sys.argv", ["versiontracker", "--audit", "--status", "bogus"]):
+            with self.assertRaises(SystemExit), patch("sys.stderr", new_callable=StringIO):
+                get_arguments()
+
+    def test_audit_all_and_status_mutually_exclusive(self):
+        """Test --all and --status cannot be combined."""
+        with patch("sys.argv", ["versiontracker", "--audit", "--all", "--status", "attention"]):
+            with self.assertRaises(SystemExit), patch("sys.stderr", new_callable=StringIO):
+                get_arguments()
+
+    def test_audit_mutually_exclusive_with_apps(self):
+        """Test --audit cannot be combined with other main action flags."""
+        with patch("sys.argv", ["versiontracker", "--audit", "--apps"]):
+            with self.assertRaises(SystemExit), patch("sys.stderr", new_callable=StringIO):
+                get_arguments()
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_auto_updates.py
+++ b/tests/test_cli_auto_updates.py
@@ -116,6 +116,7 @@ class TestMainAutoUpdatesIntegration(unittest.TestCase):
         mock_args.recom = False
         mock_args.strict_recom = False
         mock_args.check_outdated = False
+        mock_args.audit = False
         mock_args.uninstall_auto_updates = False
         mock_args.install_service = False
         mock_args.uninstall_service = False
@@ -154,6 +155,7 @@ class TestMainAutoUpdatesIntegration(unittest.TestCase):
         mock_args.recom = False
         mock_args.strict_recom = False
         mock_args.check_outdated = False
+        mock_args.audit = False
         mock_args.blacklist_auto_updates = False
         mock_args.blocklist_auto_updates = False
         mock_args.install_service = False
@@ -265,6 +267,7 @@ class TestAutoUpdatesEndToEnd(unittest.TestCase):
             mock_args.recom = False
             mock_args.strict_recom = False
             mock_args.check_outdated = False
+            mock_args.audit = False
             mock_args.uninstall_auto_updates = False
             mock_args.install_service = False
             mock_args.uninstall_service = False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,8 +3,11 @@
 import logging
 import sys
 import unittest
+from io import StringIO
 from unittest.mock import MagicMock, patch
 
+from versiontracker.__main__ import _emit_deprecation_warnings
+from versiontracker.deprecation import reset_deprecation_registry
 from versiontracker.handlers.export_handlers import handle_export
 from versiontracker.handlers.setup_handlers import handle_setup_logging
 from versiontracker.handlers.ui_handlers import get_status_color, get_status_icon
@@ -133,6 +136,57 @@ class TestMain(unittest.TestCase):
 
         # Verify that a filter was added to the StreamHandler
         mock_handler.addFilter.assert_called_once()
+
+
+class TestEmitDeprecationWarnings(unittest.TestCase):
+    """Tests for _emit_deprecation_warnings's export-aware console-hint suppression.
+
+    warn_deprecated_flag only emits once per process (see deprecation.py's
+    own registry) so the registry must be reset around each test to keep
+    them independent, per that module's own documented testing guidance.
+    """
+
+    def setUp(self):
+        reset_deprecation_registry()
+
+    def tearDown(self):
+        reset_deprecation_registry()
+
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_blacklist_without_export_prints_deprecation_hint(self, mock_stdout):
+        """Without --export, the console hint still prints (unchanged behavior)."""
+        options = MagicMock()
+        options.blacklist = "Firefox"
+        options.blacklist_auto_updates = False
+        options.export_format = None
+
+        _emit_deprecation_warnings(options)
+
+        self.assertIn("[DEPRECATION]", mock_stdout.getvalue())
+
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_blacklist_with_export_suppresses_deprecation_hint(self, mock_stdout):
+        """With --export, no stray text may precede machine-readable output."""
+        options = MagicMock()
+        options.blacklist = "Firefox"
+        options.blacklist_auto_updates = False
+        options.export_format = "json"
+
+        _emit_deprecation_warnings(options)
+
+        self.assertNotIn("[DEPRECATION]", mock_stdout.getvalue())
+        self.assertEqual(mock_stdout.getvalue(), "")
+
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_no_deprecated_flags_prints_nothing(self, mock_stdout):
+        options = MagicMock()
+        options.blacklist = None
+        options.blacklist_auto_updates = False
+        options.export_format = None
+
+        _emit_deprecation_warnings(options)
+
+        self.assertEqual(mock_stdout.getvalue(), "")
 
 
 if __name__ == "__main__":

--- a/tests/test_matcher_coverage.py
+++ b/tests/test_matcher_coverage.py
@@ -223,12 +223,23 @@ class TestFilterOutBrews:
         assert result == []
 
     @patch("versiontracker.apps.matcher.partial_ratio", return_value=90)
-    def test_strict_mode_skips_matched(self, _ratio):
+    def test_strict_mode_has_no_observable_effect_on_return_value(self, _ratio):
+        """Regression, not aspiration: filter_out_brews's `candidates` list is
+        built but never returned or used, and both the strict_mode=True and
+        strict_mode=False branches `break` identically on a match -- so
+        strict_mode currently cannot change search_list's contents. This
+        pins that (undesirable but real) current behavior; the previous
+        version of this test mocked partial_ratio to always match, which
+        made every app match under both modes and so could never have
+        actually observed a strict_mode-specific difference even if one
+        existed. See TODO.md for the tracked, separate follow-up (the
+        `--strict-recommend` CLI flag is non-functional as documented)."""
         apps = [("Firefox", "1.0"), ("SomeUnique", "2.0")]
-        result = filter_out_brews(apps, ["firefox", "someunique"], strict_mode=True)
-        # strict mode: matched apps are skipped (break without adding to candidates)
-        # All match in strict mode → all skipped → empty search_list
-        assert result == []
+
+        result_strict = filter_out_brews(apps, ["firefox", "someunique"], strict_mode=True)
+        result_lenient = filter_out_brews(apps, ["firefox", "someunique"], strict_mode=False)
+
+        assert result_strict == result_lenient == []
 
     @patch("versiontracker.apps.matcher.partial_ratio", return_value=80)
     def test_partial_fuzzy_match(self, _ratio):

--- a/tests/test_menubar_app.py
+++ b/tests/test_menubar_app.py
@@ -1,0 +1,57 @@
+"""Tests for versiontracker.menubar_app.
+
+Regression coverage: `MenubarApp.handle_menu_choice()`'s `commands` dict
+previously hard-coded `--outdated` and `--notify`, neither of which exist as
+real CLI flags -- every real click of "Check for Updates" or "Show Outdated
+Apps" would fail argparse parsing and show an error dialog instead of
+working. Zero test coverage existed for this file before this addition.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from versiontracker.cli import get_arguments
+from versiontracker.menubar_app import MenubarApp
+
+
+class TestMenubarCommandsAreValidFlags:
+    """Validated against the real argparse parser, not a hand-maintained
+    list of "known good" flags -- so a future flag rename can't silently
+    reintroduce this bug without this test catching it."""
+
+    def test_every_menu_command_parses_cleanly(self) -> None:
+        app = MenubarApp()
+        captured_args: list[list[str]] = []
+        with patch.object(app, "run_versiontracker_command", side_effect=captured_args.append):
+            for choice in (
+                "Check for Updates",
+                "Show Outdated Apps",
+                "Show All Apps",
+                "Show Homebrew Casks",
+                "Install Service",
+                "Uninstall Service",
+                "Service Status",
+            ):
+                app.handle_menu_choice(choice)
+
+        assert len(captured_args) == 7
+        for args in captured_args:
+            with patch("sys.argv", ["versiontracker", *args]):
+                get_arguments()  # raises SystemExit(2) if any flag is unrecognized
+
+    def test_check_for_updates_and_show_outdated_use_check_outdated_flag(self) -> None:
+        app = MenubarApp()
+        captured_args: list[list[str]] = []
+        with patch.object(app, "run_versiontracker_command", side_effect=captured_args.append):
+            app.handle_menu_choice("Check for Updates")
+            app.handle_menu_choice("Show Outdated Apps")
+
+        assert captured_args == [["--check-outdated"], ["--check-outdated"]]
+
+    def test_unknown_choice_does_not_run_a_command(self) -> None:
+        app = MenubarApp()
+        with patch.object(app, "run_versiontracker_command") as mock_run:
+            app.handle_menu_choice("Some Unrecognized Choice")
+
+        mock_run.assert_not_called()

--- a/versiontracker/__main__.py
+++ b/versiontracker/__main__.py
@@ -9,6 +9,7 @@ from versiontracker import __version__
 from versiontracker.cli import get_arguments
 from versiontracker.deprecation import warn_deprecated_flag
 from versiontracker.handlers import (
+    handle_audit,
     handle_blacklist_auto_updates,
     handle_brew_recommendations,
     handle_config_generation,
@@ -161,6 +162,8 @@ def _get_basic_action_result(options: Any) -> int | None:
         return handle_brew_recommendations(options)
     elif options.check_outdated:
         return handle_outdated_check(options)
+    elif options.audit:
+        return handle_audit(options)
     return None
 
 
@@ -221,18 +224,28 @@ def handle_main_actions(options: Any) -> int:
 
 
 def _emit_deprecation_warnings(options: Any) -> None:
-    """Emit deprecation warnings for legacy CLI flags."""
+    """Emit deprecation warnings for legacy CLI flags.
+
+    Suppresses the printed console hint (but not the underlying
+    logging.warning(), which always fires) when the caller requested
+    machine-readable export -- otherwise `--export json` output could have
+    a "[DEPRECATION]" line ahead of it on stdout, breaking parseability for
+    any command, not just --audit.
+    """
+    emit_console_hint = not bool(getattr(options, "export_format", None))
     if options.blacklist:
         warn_deprecated_flag(
             "--blacklist",
             replacement="--blocklist",
             removal_version="1.0.0",
+            emit_console_hint=emit_console_hint,
         )
     if options.blacklist_auto_updates:
         warn_deprecated_flag(
             "--blacklist-auto-updates",
             replacement="--blocklist-auto-updates",
             removal_version="1.0.0",
+            emit_console_hint=emit_console_hint,
         )
 
 

--- a/versiontracker/audit/__init__.py
+++ b/versiontracker/audit/__init__.py
@@ -1,0 +1,88 @@
+"""Unmanaged macOS application audit package.
+
+Phase 1: identity-preserving discovery with App Store evidence. Phase 2:
+exact Homebrew ownership + blocklist identity resolution. Phase 3: local
+auto-update capability detection. Phase 4: audit orchestration
+(service.py), terminal rendering, and JSON/YAML/CSV export (rendering.py).
+CLI wiring lives in versiontracker/handlers/audit_handlers.py and
+versiontracker/cli.py -- see
+.claude/plans/versiontracker-unmanaged-apps-handoff.md.
+"""
+
+from .auto_update import (
+    apply_auto_update_evidence,
+    build_launch_agent_index,
+    default_launch_agent_dirs,
+    resolve_auto_update_evidence,
+)
+from .blocklist import apply_blocklist_evidence, resolve_blocklist_evidence
+from .discovery import (
+    configured_discovery_roots,
+    default_discovery_roots,
+    discover_applications,
+    resolve_app_store_evidence,
+    resolve_discovery_roots,
+)
+from .homebrew import apply_homebrew_evidence, build_artifact_index, resolve_homebrew_evidence
+from .models import (
+    ApplicationRecord,
+    AppStoreEvidence,
+    AppStoreStatus,
+    AuditBucket,
+    AuditClassification,
+    AuditResult,
+    AutoUpdateEvidence,
+    AutoUpdateMechanism,
+    AutoUpdateStatus,
+    BlocklistEvidence,
+    BlocklistMatchKind,
+    BlocklistStatus,
+    ClassifiedApplication,
+    EvidenceConfidence,
+    EvidenceSource,
+    HomebrewEvidence,
+    HomebrewStatus,
+)
+from .rendering import render_csv, render_json, render_terminal, render_yaml
+from .service import classify_record, filter_result, run_audit
+
+__all__ = [
+    "ApplicationRecord",
+    "AppStoreEvidence",
+    "AppStoreStatus",
+    "AuditBucket",
+    "AuditClassification",
+    "AuditResult",
+    "AutoUpdateEvidence",
+    "AutoUpdateMechanism",
+    "AutoUpdateStatus",
+    "BlocklistEvidence",
+    "BlocklistMatchKind",
+    "BlocklistStatus",
+    "ClassifiedApplication",
+    "EvidenceConfidence",
+    "EvidenceSource",
+    "HomebrewEvidence",
+    "HomebrewStatus",
+    "apply_auto_update_evidence",
+    "apply_blocklist_evidence",
+    "apply_homebrew_evidence",
+    "build_artifact_index",
+    "build_launch_agent_index",
+    "classify_record",
+    "configured_discovery_roots",
+    "default_discovery_roots",
+    "default_launch_agent_dirs",
+    "discover_applications",
+    "filter_result",
+    "render_csv",
+    "render_json",
+    "render_terminal",
+    "render_yaml",
+    "resolve_app_store_evidence",
+    "resolve_auto_update_evidence",
+    "resolve_blocklist_evidence",
+    "resolve_discovery_roots",
+    "resolve_homebrew_evidence",
+    "run_audit",
+]

--- a/versiontracker/audit/auto_update.py
+++ b/versiontracker/audit/auto_update.py
@@ -1,0 +1,555 @@
+"""Local automatic-update capability detection for the audit feature (Phase 3).
+
+Five independent, local-only probes (Sparkle framework, Squirrel framework,
+electron-updater's app-update.yml, Mozilla's updater.app, and vendor
+LaunchAgents/Daemons tied to a bundle identifier or known vendor) each
+contribute an internal _ProbeResult; one aggregation step combines them into
+the public AutoUpdateEvidence. A Homebrew cask's `auto_updates` flag can
+supplement the result afterward, but only when local probes found nothing at
+all, and never toward ENABLED -- it reflects upstream capability, not the
+user's current preference. No network access, no subprocess calls.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import plistlib
+from collections.abc import Sequence
+from pathlib import Path
+
+import yaml
+
+from versiontracker.audit.discovery import _read_info_plist
+from versiontracker.audit.models import (
+    ApplicationRecord,
+    AutoUpdateEvidence,
+    AutoUpdateMechanism,
+    AutoUpdateStatus,
+    EvidenceConfidence,
+    EvidenceSource,
+    HomebrewStatus,
+)
+
+_UPDATER_KEYWORD = "update"
+
+# Independently-paired (agent-label-prefix, app-bundle-id-prefixes) tuples --
+# NOT a single shared string. Confirmed live that some vendors' LaunchAgent
+# label namespace and their own app's bundle-id namespace genuinely differ
+# (Dropbox's agents are `com.dropbox.*` but Dropbox.app's own bundle id is
+# `com.getdropbox.dropbox`). Comparisons are case-insensitive on both sides.
+_VENDOR_UPDATER_TIES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("com.google.keystone.", ("com.google.",)),
+    ("com.google.googleupdater.", ("com.google.",)),
+    ("com.microsoft.update.", ("com.microsoft.",)),
+    ("com.microsoft.autoupdate.", ("com.microsoft.",)),
+    ("com.adobe.", ("com.adobe.",)),  # spec-named vendor; unverified on this machine (no Adobe app installed)
+    ("com.logi.", ("com.logi.",)),
+    ("com.dropbox.", ("com.getdropbox.",)),
+    ("us.zoom.updater.", ("us.zoom.",)),
+    ("org.gpgtools.updater.", ("org.gpgtools.",)),
+)
+
+_CONFIDENCE_RANK = {
+    EvidenceConfidence.HIGH: 3,
+    EvidenceConfidence.MEDIUM: 2,
+    EvidenceConfidence.LOW: 1,
+    EvidenceConfidence.NONE: 0,
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class _ProbeResult:
+    """Internal: one mechanism probe's finding for one application record."""
+
+    mechanism: AutoUpdateMechanism
+    found: bool
+    confidence: EvidenceConfidence
+    detail: str
+    matched_identifier: str | None = None
+    enabled: bool | None = None  # only Sparkle's preference read ever sets True/False
+    error: str | None = None  # may coexist with found=True -- see _aggregate_probe_results
+
+
+@dataclasses.dataclass(frozen=True)
+class _LaunchAgentCandidate:
+    """Internal: one *.plist file found while scanning LaunchAgent/Daemon dirs."""
+
+    path: Path
+    filename_stem: str
+    label: str | None
+
+
+def default_launch_agent_dirs() -> list[Path]:
+    """Built-in LaunchAgent/LaunchDaemon scan locations.
+
+    Computed per call (not at import time) so tests can patch Path.home().
+    """
+    return [
+        Path("/Library/LaunchDaemons"),
+        Path("/Library/LaunchAgents"),
+        Path.home() / "Library" / "LaunchAgents",
+    ]
+
+
+def _read_launch_agent_label(path: Path) -> str | None:
+    """Best-effort read of a LaunchAgent/Daemon plist's Label key.
+
+    Returns None on any read/parse failure, missing key, or non-string
+    value -- never raises. Confirmed live that some vendor LaunchDaemons are
+    root-owned and mode 600 (unreadable by an unprivileged process); this is
+    exactly the case that degrades gracefully here -- the candidate's
+    filename_stem remains usable even when its content isn't. Deliberately
+    catches Exception broadly, not a specific tuple: confirmed live on this
+    real machine that a genuinely malformed plist (a real, unrelated
+    LaunchAgent with corrupt XML content) raises xml.parsers.expat.ExpatError
+    via plistlib's XML parser -- neither OSError, ValueError, nor
+    plistlib.InvalidFileException, so a narrower tuple would have let a real
+    LaunchAgent scan crash the whole audit.
+    """
+    try:
+        with path.open("rb") as f:
+            data = plistlib.load(f)
+    except Exception as e:
+        logging.debug("Could not read LaunchAgent/Daemon label for %s: %s", path, e)
+        return None
+    label = data.get("Label") if isinstance(data, dict) else None
+    return label if isinstance(label, str) else None
+
+
+def build_launch_agent_index(
+    dirs: Sequence[Path],
+) -> tuple[tuple[_LaunchAgentCandidate, ...], tuple[str, ...]]:
+    """Enumerate *.plist files across the given directories once.
+
+    Never raises. A directory that can't be listed (missing, permission
+    denied) contributes a scan error but doesn't abort scanning the other
+    directories.
+    """
+    candidates: list[_LaunchAgentCandidate] = []
+    scan_errors: list[str] = []
+
+    for directory in dirs:
+        try:
+            entries = list(directory.iterdir())
+        except OSError as e:
+            logging.debug("Could not list %s: %s", directory, e)
+            scan_errors.append(f"Could not list {directory}: {e}")
+            continue
+
+        for entry in entries:
+            if entry.suffix.lower() != ".plist":
+                continue
+            try:
+                is_file = entry.is_file()
+            except OSError:
+                continue
+            if not is_file:
+                continue
+            candidates.append(
+                _LaunchAgentCandidate(path=entry, filename_stem=entry.stem, label=_read_launch_agent_label(entry))
+            )
+
+    return tuple(candidates), tuple(scan_errors)
+
+
+def _probe_sparkle(bundle_path: Path) -> _ProbeResult:
+    """Sparkle framework presence + SUEnableAutomaticChecks preference.
+
+    Framework presence is the reliable signal -- confirmed against 14 real
+    Sparkle apps, Info.plist SU* keys are sparse/inconsistent (some real
+    apps have none at all despite the framework definitely being present).
+    """
+    framework_path = bundle_path / "Contents" / "Frameworks" / "Sparkle.framework"
+    try:
+        present = framework_path.is_dir()
+    except OSError as e:
+        return _ProbeResult(
+            mechanism=AutoUpdateMechanism.SPARKLE_FRAMEWORK,
+            found=False,
+            confidence=EvidenceConfidence.NONE,
+            detail="Could not check for Sparkle.framework",
+            error=str(e),
+        )
+    if not present:
+        return _ProbeResult(
+            mechanism=AutoUpdateMechanism.SPARKLE_FRAMEWORK,
+            found=False,
+            confidence=EvidenceConfidence.NONE,
+            detail="Sparkle.framework not found",
+        )
+
+    enabled = _read_info_plist(bundle_path).get("SUEnableAutomaticChecks")
+    if enabled is True:
+        detail = "Sparkle.framework present; SUEnableAutomaticChecks=true"
+    elif enabled is False:
+        detail = "Sparkle.framework present; SUEnableAutomaticChecks=false (explicitly disabled)"
+    else:
+        detail = "Sparkle.framework present; auto-check preference not set in Info.plist"
+
+    return _ProbeResult(
+        mechanism=AutoUpdateMechanism.SPARKLE_FRAMEWORK,
+        found=True,
+        confidence=EvidenceConfidence.HIGH,
+        detail=detail,
+        matched_identifier="Sparkle.framework",
+        enabled=enabled if isinstance(enabled, bool) else None,
+    )
+
+
+def _probe_squirrel(bundle_path: Path) -> _ProbeResult:
+    """Squirrel framework presence (ShipIt helper noted as corroboration).
+
+    ShipIt (Sparkle's privileged-install helper) is nested inside Squirrel's
+    own Resources -- confirmed live -- so it's folded into this probe's
+    detail rather than treated as a separate probe.
+    """
+    framework_path = bundle_path / "Contents" / "Frameworks" / "Squirrel.framework"
+    try:
+        present = framework_path.is_dir()
+    except OSError as e:
+        return _ProbeResult(
+            mechanism=AutoUpdateMechanism.SQUIRREL_FRAMEWORK,
+            found=False,
+            confidence=EvidenceConfidence.NONE,
+            detail="Could not check for Squirrel.framework",
+            error=str(e),
+        )
+    if not present:
+        return _ProbeResult(
+            mechanism=AutoUpdateMechanism.SQUIRREL_FRAMEWORK,
+            found=False,
+            confidence=EvidenceConfidence.NONE,
+            detail="Squirrel.framework not found",
+        )
+
+    has_shipit = False
+    try:
+        has_shipit = (framework_path / "Resources" / "ShipIt").exists()
+    except OSError:
+        pass
+
+    detail = "Squirrel.framework present" + (" (with ShipIt helper)" if has_shipit else "")
+    return _ProbeResult(
+        mechanism=AutoUpdateMechanism.SQUIRREL_FRAMEWORK,
+        found=True,
+        confidence=EvidenceConfidence.HIGH,
+        detail=detail,
+        matched_identifier="Squirrel.framework",
+    )
+
+
+def _probe_electron_updater_yml(bundle_path: Path) -> _ProbeResult:
+    """electron-updater's app-update.yml.
+
+    Distinct from Squirrel -- confirmed live that a single Electron app can
+    carry both an old Squirrel.framework build and newer app-update.yml
+    metadata simultaneously, so this probe never treats Squirrel presence as
+    a reason to skip this check. File content has no enabled/disabled
+    toggle (confirmed against real files) -- presence is capability-only.
+    """
+    yml_path = bundle_path / "Contents" / "Resources" / "app-update.yml"
+    try:
+        present = yml_path.is_file()
+    except OSError as e:
+        return _ProbeResult(
+            mechanism=AutoUpdateMechanism.ELECTRON_UPDATER_YML,
+            found=False,
+            confidence=EvidenceConfidence.NONE,
+            detail="Could not check for app-update.yml",
+            error=str(e),
+        )
+    if not present:
+        return _ProbeResult(
+            mechanism=AutoUpdateMechanism.ELECTRON_UPDATER_YML,
+            found=False,
+            confidence=EvidenceConfidence.NONE,
+            detail="app-update.yml not found",
+        )
+
+    provider: str | None = None
+    try:
+        with yml_path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if isinstance(data, dict):
+            provider_value = data.get("provider")
+            provider = provider_value if isinstance(provider_value, str) else None
+    except (OSError, yaml.YAMLError) as e:
+        # Secondary-detail failure only (a malformed/unreadable body) --
+        # existence itself was already confirmed above, so this stays found=True.
+        logging.debug("Could not parse app-update.yml at %s: %s", yml_path, e)
+
+    detail = "app-update.yml present" + (f" (provider={provider})" if provider else "")
+    return _ProbeResult(
+        mechanism=AutoUpdateMechanism.ELECTRON_UPDATER_YML,
+        found=True,
+        confidence=EvidenceConfidence.HIGH,
+        detail=detail,
+        matched_identifier="app-update.yml",
+    )
+
+
+def _probe_mozilla_updater(bundle_path: Path) -> _ProbeResult:
+    """Mozilla-style updater probe: Contents/MacOS/updater.app.
+
+    A corroborating updater.ini / org.mozilla.updater LaunchServices entry
+    bumps confidence. Multiplicity affects confidence, not inclusion -- a
+    stricter all-three-required gate would risk false negatives on a
+    legitimate partial build for no real gain, since a coincidental
+    unrelated updater.app directory would still be a correct positive, not
+    a false one.
+    """
+    updater_app = bundle_path / "Contents" / "MacOS" / "updater.app"
+    try:
+        present = updater_app.is_dir()
+    except OSError as e:
+        return _ProbeResult(
+            mechanism=AutoUpdateMechanism.MOZILLA_UPDATER,
+            found=False,
+            confidence=EvidenceConfidence.NONE,
+            detail="Could not check for Contents/MacOS/updater.app",
+            error=str(e),
+        )
+    if not present:
+        return _ProbeResult(
+            mechanism=AutoUpdateMechanism.MOZILLA_UPDATER,
+            found=False,
+            confidence=EvidenceConfidence.NONE,
+            detail="Contents/MacOS/updater.app not found",
+        )
+
+    corroborating = 0
+    for candidate in (
+        bundle_path / "Contents" / "Resources" / "updater.ini",
+        bundle_path / "Contents" / "Library" / "LaunchServices" / "org.mozilla.updater",
+    ):
+        try:
+            if candidate.is_file():
+                corroborating += 1
+        except OSError:
+            pass
+
+    confidence = EvidenceConfidence.HIGH if corroborating > 0 else EvidenceConfidence.MEDIUM
+    return _ProbeResult(
+        mechanism=AutoUpdateMechanism.MOZILLA_UPDATER,
+        found=True,
+        confidence=confidence,
+        detail=f"Contents/MacOS/updater.app present ({corroborating} corroborating file(s))",
+        matched_identifier="Contents/MacOS/updater.app",
+    )
+
+
+def _candidate_identifiers(candidate: _LaunchAgentCandidate) -> list[tuple[str, EvidenceConfidence]]:
+    """Return every identifier worth testing for this candidate, in priority order.
+
+    Label and filename stem are checked independently, not one-with-a-
+    fallback -- confirmed live that they can diverge in both directions: a
+    real, root-owned, mode-600 vendor updater daemon's content is
+    unreadable (Label unavailable, filename still usable), and a real
+    LaunchAgent's filename doesn't always match its own internal Label even
+    when both ARE readable. Relying on only one would miss real matches the
+    other would have caught. Label (when present) is checked first and
+    reported preferentially when both match, since it's the more
+    authoritative identifier when readable.
+    """
+    identifiers: list[tuple[str, EvidenceConfidence]] = []
+    if candidate.label:
+        identifiers.append((candidate.label, EvidenceConfidence.HIGH))
+    identifiers.append((candidate.filename_stem, EvidenceConfidence.MEDIUM))
+    return identifiers
+
+
+def _probe_vendor_launch_agent(
+    record: ApplicationRecord,
+    candidates: Sequence[_LaunchAgentCandidate],
+    scan_errors: Sequence[str],
+) -> _ProbeResult:
+    """Tie a LaunchAgent/Daemon to this record via its bundle_id (exact tier) or a known vendor (vendor tier).
+
+    Exact-prefix matching on structured reverse-DNS identifiers, not
+    similarity scoring -- deterministic and does not fall under the
+    "do not use fuzzy matching to prove ownership" guardrail. Confirmed
+    live this needs an "update" keyword guard on the exact tier (ClamXAV's
+    .Engine.plist/.HelperTool.plist share a bundle-id prefix with the real
+    .HelperToolUpdater.plist but aren't updaters) and independently-paired
+    vendor prefixes on the vendor tier (see _VENDOR_UPDATER_TIES).
+    """
+    error = "; ".join(scan_errors) if scan_errors else None
+
+    if not record.bundle_id:
+        return _ProbeResult(
+            mechanism=AutoUpdateMechanism.VENDOR_LAUNCH_AGENT,
+            found=False,
+            confidence=EvidenceConfidence.NONE,
+            detail="No bundle identifier to tie a LaunchAgent/Daemon to",
+            error=error,
+        )
+
+    bundle_id_lower = record.bundle_id.lower()
+
+    for candidate in candidates:
+        for identifier, confidence in _candidate_identifiers(candidate):
+            identifier_lower = identifier.lower()
+            if identifier_lower.startswith(bundle_id_lower) and _UPDATER_KEYWORD in identifier_lower:
+                return _ProbeResult(
+                    mechanism=AutoUpdateMechanism.VENDOR_LAUNCH_AGENT,
+                    found=True,
+                    confidence=confidence,
+                    detail=f"LaunchAgent/Daemon '{identifier}' is tied to this app's own bundle identifier",
+                    matched_identifier=identifier,
+                    error=error,
+                )
+
+    for candidate in candidates:
+        for identifier, _confidence in _candidate_identifiers(candidate):
+            identifier_lower = identifier.lower()
+            for agent_prefix, app_prefixes in _VENDOR_UPDATER_TIES:
+                if identifier_lower.startswith(agent_prefix) and any(
+                    bundle_id_lower.startswith(app_prefix) for app_prefix in app_prefixes
+                ):
+                    return _ProbeResult(
+                        mechanism=AutoUpdateMechanism.VENDOR_LAUNCH_AGENT,
+                        found=True,
+                        confidence=EvidenceConfidence.LOW,
+                        detail=f"LaunchAgent/Daemon '{identifier}' belongs to a known vendor's suite-wide updater",
+                        matched_identifier=identifier,
+                        error=error,
+                    )
+
+    return _ProbeResult(
+        mechanism=AutoUpdateMechanism.VENDOR_LAUNCH_AGENT,
+        found=False,
+        confidence=EvidenceConfidence.NONE,
+        detail="No LaunchAgent/Daemon tied to this app's bundle identifier or a known vendor",
+        error=error,
+    )
+
+
+def _aggregate_probe_results(results: Sequence[_ProbeResult]) -> AutoUpdateEvidence:
+    """Combine independent probe results into one AutoUpdateEvidence.
+
+    A probe error never suppresses a positive finding from a different
+    probe -- CAPABLE/ENABLED is decided from `positives` first, independent
+    of `errors`; an error alongside a positive becomes a reason caveat, not
+    `.error` (matching existing precedent: `.error` is only populated on the
+    evidence's own failed status). `mechanisms` records every contributing
+    positive probe, not just the deciding one -- some real apps genuinely
+    have two simultaneously-true mechanisms (e.g. Squirrel.framework AND
+    app-update.yml).
+    """
+    positives = [r for r in results if r.found]
+    errors = [r for r in results if r.error]
+    mechanisms = tuple(r.mechanism for r in positives)
+    matched_identifier = next((r.matched_identifier for r in positives if r.matched_identifier), None)
+
+    if any(r.enabled is True for r in positives):
+        return AutoUpdateEvidence(
+            status=AutoUpdateStatus.ENABLED,
+            reason="; ".join(r.detail for r in positives),
+            source=EvidenceSource.FILESYSTEM,
+            matched_identifier=matched_identifier,
+            confidence=EvidenceConfidence.HIGH,
+            mechanisms=mechanisms,
+        )
+
+    if positives:
+        confidence = max((r.confidence for r in positives), key=lambda c: _CONFIDENCE_RANK[c])
+        reason = "; ".join(r.detail for r in positives)
+        if errors:
+            error_detail = "; ".join(e.error for e in errors if e.error)
+            reason += f"; {len(errors)} probe(s) could not complete: {error_detail}"
+        return AutoUpdateEvidence(
+            status=AutoUpdateStatus.CAPABLE,
+            reason=reason,
+            source=EvidenceSource.FILESYSTEM,
+            matched_identifier=matched_identifier,
+            confidence=confidence,
+            mechanisms=mechanisms,
+        )
+
+    if errors:
+        error_detail = "; ".join(e.error for e in errors if e.error)
+        return AutoUpdateEvidence(
+            status=AutoUpdateStatus.UNKNOWN,
+            reason=f"Could not complete all local auto-update probes: {error_detail}",
+            source=EvidenceSource.FILESYSTEM,
+            confidence=EvidenceConfidence.NONE,
+            error=error_detail,
+        )
+
+    return AutoUpdateEvidence(
+        status=AutoUpdateStatus.NONE_DETECTED,
+        reason="All local auto-update probes completed without evidence",
+        source=EvidenceSource.FILESYSTEM,
+        confidence=EvidenceConfidence.MEDIUM,
+    )
+
+
+def _apply_homebrew_cask_supplement(evidence: AutoUpdateEvidence, record: ApplicationRecord) -> AutoUpdateEvidence:
+    """Supplement with the owning cask's auto_updates flag.
+
+    Only applied when local probes found nothing at all (never overriding
+    a positive or an unknown), and never toward ENABLED, since the cask
+    flag indicates upstream capability, not the user's current preference.
+    """
+    if record.homebrew.status is not HomebrewStatus.MANAGED:
+        return evidence
+    if record.homebrew.cask_auto_updates is not True:
+        return evidence
+    if evidence.status is not AutoUpdateStatus.NONE_DETECTED:
+        return evidence
+
+    return dataclasses.replace(
+        evidence,
+        status=AutoUpdateStatus.CAPABLE,
+        reason=(
+            "No local probe found evidence, but the owning Homebrew cask "
+            f"'{record.homebrew.matched_identifier}' declares auto_updates=true"
+        ),
+        confidence=EvidenceConfidence.LOW,
+        matched_identifier=record.homebrew.matched_identifier,
+        mechanisms=(AutoUpdateMechanism.HOMEBREW_CASK_AUTO_UPDATES,),
+    )
+
+
+def resolve_auto_update_evidence(
+    record: ApplicationRecord,
+    *,
+    launch_agent_candidates: Sequence[_LaunchAgentCandidate],
+    launch_agent_scan_errors: Sequence[str] = (),
+) -> AutoUpdateEvidence:
+    """Run all local probes for one record, aggregate, then apply the Homebrew cask auto_updates supplement."""
+    results = [
+        _probe_sparkle(record.canonical_path),
+        _probe_squirrel(record.canonical_path),
+        _probe_electron_updater_yml(record.canonical_path),
+        _probe_mozilla_updater(record.canonical_path),
+        _probe_vendor_launch_agent(record, launch_agent_candidates, launch_agent_scan_errors),
+    ]
+    evidence = _aggregate_probe_results(results)
+    return _apply_homebrew_cask_supplement(evidence, record)
+
+
+def apply_auto_update_evidence(
+    records: Sequence[ApplicationRecord], *, launch_agent_dirs: Sequence[Path] | None = None
+) -> list[ApplicationRecord]:
+    """Resolve and attach auto-update evidence to each record, returning new records.
+
+    Builds the LaunchAgent/Daemon index once, shared across all records.
+    `launch_agent_dirs`, when given, fully replaces the default scan
+    locations -- the same hermetic escape hatch `discover_applications(roots=...)`
+    established; tests must never enumerate the real machine's actual
+    LaunchAgents/Daemons.
+    """
+    dirs = list(launch_agent_dirs) if launch_agent_dirs is not None else default_launch_agent_dirs()
+    candidates, scan_errors = build_launch_agent_index(dirs)
+
+    return [
+        dataclasses.replace(
+            record,
+            auto_update=resolve_auto_update_evidence(
+                record, launch_agent_candidates=candidates, launch_agent_scan_errors=scan_errors
+            ),
+        )
+        for record in records
+    ]

--- a/versiontracker/audit/blocklist.py
+++ b/versiontracker/audit/blocklist.py
@@ -1,0 +1,154 @@
+"""Blocklist identity resolution for the audit feature (Phase 2).
+
+Blocklist entries are matched by structured identity -- canonical path,
+bundle identifier, associated Homebrew cask token, and (weakest) normalized
+display name -- rather than versiontracker.config.Config.is_blocklisted()'s
+pure display-name comparison, which cannot distinguish a cask token like
+"visual-studio-code" (written into the same list by the existing
+--blocklist-auto-updates flag) from the display name "Visual Studio Code"
+it's meant to match.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+from versiontracker.audit.models import (
+    ApplicationRecord,
+    BlocklistEvidence,
+    BlocklistMatchKind,
+    BlocklistStatus,
+    EvidenceConfidence,
+    EvidenceSource,
+)
+from versiontracker.config import get_config
+from versiontracker.exceptions import ConfigError
+
+
+def _try_resolve_path_entry(entry: str) -> Path | None:
+    """Resolve a blocklist entry as a path, but only if it already looks like one.
+
+    A bare relative fragment (e.g. a typo'd "Keynote.app" meant as a display
+    name) must NOT be resolved against the process's cwd -- that would make
+    the same config match or not match depending on where versiontracker
+    happens to be launched from. Only entries already absolute or
+    `~`-prefixed are eligible for canonical-path matching.
+    """
+    try:
+        candidate = Path(entry).expanduser()
+        if not candidate.is_absolute():
+            return None
+        return candidate.resolve()
+    except (OSError, RuntimeError, ValueError) as e:
+        logging.debug("Could not resolve blocklist entry as a path: %r (%s)", entry, e)
+        return None
+
+
+def _blocked(
+    matched_entry: str,
+    matched_by: BlocklistMatchKind,
+    reason: str,
+    *,
+    confidence: EvidenceConfidence = EvidenceConfidence.HIGH,
+) -> BlocklistEvidence:
+    return BlocklistEvidence(
+        status=BlocklistStatus.BLOCKED,
+        reason=reason,
+        source=EvidenceSource.CONFIG,
+        matched_identifier=matched_entry,
+        matched_by=matched_by,
+        confidence=confidence,
+    )
+
+
+def resolve_blocklist_evidence(record: ApplicationRecord, blocklist_entries: Iterable[str]) -> BlocklistEvidence:
+    """Resolve blocklist status for one record via structured identity matching.
+
+    Checks, strongest first: canonical path, bundle identifier, Homebrew
+    cask token, normalized display name. The cask-token tier reads
+    record.homebrew.matched_identifier, which is None for every
+    HomebrewStatus except MANAGED -- so this degrades gracefully (not a
+    crash) whether or not Homebrew evidence has been resolved yet for this
+    record; there is no service.py in this phase to enforce resolution
+    order, so this function must tolerate either order on its own.
+    """
+    entries = [entry for entry in blocklist_entries if isinstance(entry, str)]
+
+    for entry in entries:
+        resolved_entry = _try_resolve_path_entry(entry)
+        if resolved_entry is not None and resolved_entry == record.canonical_path:
+            return _blocked(
+                entry,
+                BlocklistMatchKind.CANONICAL_PATH,
+                f"Matches canonical path '{record.canonical_path}'",
+            )
+
+    if record.bundle_id:
+        for entry in entries:
+            if entry == record.bundle_id:
+                return _blocked(
+                    entry,
+                    BlocklistMatchKind.BUNDLE_ID,
+                    f"Matches bundle identifier '{record.bundle_id}'",
+                )
+
+    homebrew_token = record.homebrew.matched_identifier
+    if homebrew_token:
+        for entry in entries:
+            if entry.strip().lower() == homebrew_token.strip().lower():
+                return _blocked(
+                    entry,
+                    BlocklistMatchKind.HOMEBREW_TOKEN,
+                    f"Matches Homebrew cask token '{homebrew_token}'",
+                )
+
+    normalized_name = record.name.strip().lower()
+    for entry in entries:
+        if entry.strip().lower() == normalized_name:
+            return _blocked(
+                entry,
+                BlocklistMatchKind.DISPLAY_NAME,
+                f"Matches display name '{record.name}'",
+                confidence=EvidenceConfidence.MEDIUM,
+            )
+
+    return BlocklistEvidence(
+        status=BlocklistStatus.NOT_BLOCKED,
+        reason="No blocklist entry matches this application's path, bundle identifier, Homebrew token, or display name",
+        source=EvidenceSource.CONFIG,
+        confidence=EvidenceConfidence.HIGH,
+    )
+
+
+def apply_blocklist_evidence(
+    records: Sequence[ApplicationRecord], blocklist_entries: Iterable[str] | None = None
+) -> list[ApplicationRecord]:
+    """Resolve and attach blocklist evidence to each record, returning new records.
+
+    Defaults to get_config().get_blocklist() -- the existing, already-unified
+    accessor that merges legacy `blacklist` with modern `blocklist` config
+    keys -- when blocklist_entries isn't given explicitly. A malformed
+    config file can raise ConfigError on that call; this degrades every
+    record to BlocklistStatus.UNKNOWN rather than propagating and crashing
+    the whole audit.
+    """
+    if blocklist_entries is not None:
+        entries = list(blocklist_entries)
+    else:
+        try:
+            entries = get_config().get_blocklist()
+        except ConfigError as e:
+            logging.warning("Blocklist resolution unavailable: %s", e)
+            unknown = BlocklistEvidence(
+                status=BlocklistStatus.UNKNOWN,
+                reason="Could not load blocklist configuration",
+                source=EvidenceSource.CONFIG,
+                confidence=EvidenceConfidence.NONE,
+                error=str(e),
+            )
+            return [dataclasses.replace(record, blocklist=unknown) for record in records]
+
+    return [dataclasses.replace(record, blocklist=resolve_blocklist_evidence(record, entries)) for record in records]

--- a/versiontracker/audit/discovery.py
+++ b/versiontracker/audit/discovery.py
@@ -1,0 +1,378 @@
+"""Identity-preserving discovery for the unmanaged macOS application audit feature.
+
+Discovery walks the filesystem directly under the resolved roots (default
+locations, configured additional_app_dirs, and caller-supplied extra roots).
+Parsed system_profiler data, if supplied, is used only to *enrich* records
+already found by the walk (name/version/obtained_from) -- it is never the
+source of which bundles exist, since additional_app_dirs and ~/Applications
+entries are not guaranteed to already be indexed by system_profiler.
+
+No network access, no subprocess calls.
+"""
+
+from __future__ import annotations
+
+import logging
+import plistlib
+from collections.abc import Iterator, Sequence
+from pathlib import Path
+from typing import Any
+
+from versiontracker.audit.models import (
+    ApplicationRecord,
+    AppStoreEvidence,
+    AppStoreStatus,
+    EvidenceConfidence,
+    EvidenceSource,
+)
+from versiontracker.config import get_config
+
+_APP_SUFFIX = ".app"
+_APP_STORE_OBTAINED_FROM_VALUES = frozenset({"mac_app_store", "ios_app_store"})
+
+
+def default_discovery_roots() -> list[Path]:
+    """Built-in discovery roots: /Applications and ~/Applications.
+
+    Computed per call (not at import time) so tests can patch Path.home().
+    """
+    return [Path("/Applications"), Path.home() / "Applications"]
+
+
+def configured_discovery_roots() -> list[Path]:
+    """Additional roots from config (additional_app_dirs).
+
+    Reads via Config.get("additional_app_dirs", []) -- the real accessor.
+    getattr(get_config(), "additional_app_dirs", default) must NOT be used
+    here: Config has no such attribute or property, so getattr would always
+    silently return the fallback default instead of the configured value.
+    """
+    raw_dirs = get_config().get("additional_app_dirs", [])
+    return [Path(entry) for entry in raw_dirs]
+
+
+def resolve_discovery_roots(extra_roots: Sequence[str | Path] | None = None) -> list[Path]:
+    """Combine default, configured, and caller-supplied roots.
+
+    extra_roots stands in for the future CLI --additional-dirs flag (wired
+    up in a later phase); here it is just a plain, additive parameter. Roots
+    are expanded (~), resolved, and de-duplicated in first-seen order.
+    """
+    candidates: list[Path] = [*default_discovery_roots(), *configured_discovery_roots()]
+    if extra_roots:
+        candidates.extend(Path(entry) for entry in extra_roots)
+
+    resolved: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in candidates:
+        try:
+            resolved_candidate = candidate.expanduser().resolve()
+        except OSError as e:
+            logging.debug("Could not resolve discovery root %s: %s", candidate, e)
+            continue
+        if resolved_candidate not in seen:
+            seen.add(resolved_candidate)
+            resolved.append(resolved_candidate)
+    return resolved
+
+
+def _log_walk_error(error: OSError) -> None:
+    logging.debug("Cannot list a directory during discovery walk: %s", error)
+
+
+def _walk_root(root: Path, *, include_nested: bool) -> Iterator[Path]:
+    """Yield raw (not yet resolved) paths of .app bundles found under root.
+
+    Uses Path.walk() (top-down, no symlink following) so that, when
+    include_nested is False, matched bundle directories can be pruned from
+    dirnames in place -- the standard os.walk/Path.walk idiom for stopping
+    descent into an already-matched directory. When include_nested is True,
+    no pruning happens, so the walk naturally continues into Contents/... and
+    finds nested helper bundles too.
+    """
+    if not root.is_dir():
+        return
+
+    for dirpath, dirnames, _filenames in root.walk(top_down=True, on_error=_log_walk_error, follow_symlinks=False):
+        app_dirnames = [d for d in dirnames if d.lower().endswith(_APP_SUFFIX)]
+        for app_dirname in app_dirnames:
+            yield dirpath / app_dirname
+        if not include_nested:
+            dirnames[:] = [d for d in dirnames if d not in app_dirnames]
+
+
+def _nearest_parent_bundle(path: Path, root: Path) -> Path | None:
+    """Nearest `.app` ancestor of `path` strictly between `root` and `path`, or None if not nested.
+
+    Walks from root down to path (not path's own final component) so the
+    last .app ancestor encountered is the nearest enclosing bundle.
+    """
+    try:
+        relative_parts = path.relative_to(root).parts
+    except ValueError:
+        return None
+
+    current = root
+    nearest: Path | None = None
+    for part in relative_parts[:-1]:
+        current = current / part
+        if current.suffix.lower() == _APP_SUFFIX:
+            nearest = current
+    return nearest
+
+
+def _read_info_plist(bundle_path: Path) -> dict[str, Any]:
+    """Read Contents/Info.plist, returning {} on any read/parse failure.
+
+    Never raises -- same defensive pattern as
+    versiontracker/plugins/example_plugins.py::_get_app_info. Deliberately
+    catches Exception broadly, not a specific tuple: confirmed live on a
+    real machine that a genuinely malformed plist can raise
+    xml.parsers.expat.ExpatError (via plistlib's XML parser), which is
+    neither OSError, ValueError, nor plistlib.InvalidFileException -- a
+    narrower tuple silently fails this function's own "never raises"
+    contract the moment a real Info.plist is corrupt.
+    """
+    plist_path = bundle_path / "Contents" / "Info.plist"
+    try:
+        with plist_path.open("rb") as f:
+            data = plistlib.load(f)
+    except Exception as e:
+        logging.debug("Could not read Info.plist for %s: %s", bundle_path, e)
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _has_mas_receipt(bundle_path: Path) -> bool | None:
+    """Check for Contents/_MASReceipt/receipt.
+
+    Returns True/False when the check completed, or None if the filesystem
+    probe itself failed (e.g. permission denied) -- distinct from a
+    confirmed absence, so callers can tell "not App Store" apart from
+    "couldn't determine."
+    """
+    receipt_path = bundle_path / "Contents" / "_MASReceipt" / "receipt"
+    try:
+        return receipt_path.exists()
+    except OSError as e:
+        logging.debug("Could not check Mac App Store receipt for %s: %s", bundle_path, e)
+        return None
+
+
+def resolve_app_store_evidence(bundle_path: Path, obtained_from: str | None) -> AppStoreEvidence:
+    """Resolve App Store evidence from two independent local signals.
+
+    Signal 1: system_profiler's obtained_from value (mac_app_store /
+    ios_app_store indicate a store install; any other non-empty value does
+    not). Signal 2: presence of Contents/_MASReceipt/receipt, which macOS
+    requires for a genuine App Store install. When the signals conflict, the
+    receipt is treated as the more mechanically authoritative one (
+    obtained_from can be stale, or simply unavailable for bundles the
+    filesystem walk found but system_profiler didn't index) -- but the
+    conflict is always recorded in `reason`, never silently dropped. Only a
+    failed filesystem probe (permission/I-O error) yields UNKNOWN.
+    """
+    normalized_obtained_from = obtained_from.strip().lower() if obtained_from else None
+    reports_app_store = normalized_obtained_from in _APP_STORE_OBTAINED_FROM_VALUES
+
+    has_receipt = _has_mas_receipt(bundle_path)
+    if has_receipt is None:
+        return AppStoreEvidence(
+            status=AppStoreStatus.UNKNOWN,
+            reason="Could not check for a Mac App Store receipt (filesystem probe failed)",
+            source=EvidenceSource.FILESYSTEM,
+            confidence=EvidenceConfidence.NONE,
+            error="permission or I/O error reading Contents/_MASReceipt/receipt",
+        )
+
+    if normalized_obtained_from is None:
+        if has_receipt:
+            return AppStoreEvidence(
+                status=AppStoreStatus.APP_STORE,
+                reason="No system_profiler obtained_from was available; a Mac App Store receipt was found",
+                source=EvidenceSource.FILESYSTEM,
+                matched_identifier="_MASReceipt/receipt",
+                confidence=EvidenceConfidence.MEDIUM,
+            )
+        return AppStoreEvidence(
+            status=AppStoreStatus.NOT_APP_STORE,
+            reason="No system_profiler obtained_from was available and no Mac App Store receipt was found",
+            source=EvidenceSource.FILESYSTEM,
+            confidence=EvidenceConfidence.MEDIUM,
+        )
+
+    if reports_app_store and has_receipt:
+        return AppStoreEvidence(
+            status=AppStoreStatus.APP_STORE,
+            reason=f"system_profiler reported obtained_from='{normalized_obtained_from}', corroborated by a Mac App Store receipt",
+            source=EvidenceSource.SYSTEM_PROFILER,
+            matched_identifier=normalized_obtained_from,
+            confidence=EvidenceConfidence.HIGH,
+        )
+    if reports_app_store and not has_receipt:
+        return AppStoreEvidence(
+            status=AppStoreStatus.APP_STORE,
+            reason=(
+                f"system_profiler reported obtained_from='{normalized_obtained_from}' "
+                "but no Contents/_MASReceipt/receipt was found"
+            ),
+            source=EvidenceSource.SYSTEM_PROFILER,
+            matched_identifier=normalized_obtained_from,
+            confidence=EvidenceConfidence.MEDIUM,
+        )
+    if not reports_app_store and has_receipt:
+        return AppStoreEvidence(
+            status=AppStoreStatus.APP_STORE,
+            reason=(
+                "Contents/_MASReceipt/receipt is present, which conflicts with system_profiler's "
+                f"obtained_from='{normalized_obtained_from}'; treating the receipt as authoritative"
+            ),
+            source=EvidenceSource.FILESYSTEM,
+            matched_identifier="_MASReceipt/receipt",
+            confidence=EvidenceConfidence.MEDIUM,
+        )
+    return AppStoreEvidence(
+        status=AppStoreStatus.NOT_APP_STORE,
+        reason=(
+            f"system_profiler reported obtained_from='{normalized_obtained_from}', not an App Store "
+            "source, and no receipt was found"
+        ),
+        source=EvidenceSource.SYSTEM_PROFILER,
+        matched_identifier=normalized_obtained_from,
+        confidence=EvidenceConfidence.HIGH,
+    )
+
+
+def _build_sp_index(system_profiler_data: dict[str, Any] | None) -> dict[Path, dict[str, Any]]:
+    """Index system_profiler entries by canonical path for enrichment lookups."""
+    index: dict[Path, dict[str, Any]] = {}
+    entries = (system_profiler_data or {}).get("SPApplicationsDataType", [])
+    for entry in entries:
+        raw_path = entry.get("path")
+        if not raw_path:
+            continue
+        try:
+            canonical = Path(raw_path).expanduser().resolve()
+        except OSError as e:
+            logging.debug("Could not resolve system_profiler path %r: %s", raw_path, e)
+            continue
+        index[canonical] = entry
+    return index
+
+
+def _build_record(
+    raw_path: Path,
+    canonical_path: Path,
+    parent_bundle_path: Path | None,
+    sp_index: dict[Path, dict[str, Any]],
+) -> ApplicationRecord:
+    """Build one record for a discovered bundle.
+
+    Prefers system_profiler's fields when a matching entry was found (the
+    long-standing primary data source), falling back to Contents/Info.plist
+    and the bundle's own filename otherwise. Missing name/version/bundle_id
+    are recorded as diagnostics rather than dropping the entry -- unlike
+    legacy finder.get_applications(), which silently skips on KeyError.
+    """
+    plist_data = _read_info_plist(canonical_path)
+    sp_entry = sp_index.get(canonical_path)
+
+    diagnostics: list[str] = []
+
+    name = ""
+    if sp_entry and sp_entry.get("_name"):
+        name = str(sp_entry["_name"])
+    elif plist_data.get("CFBundleName"):
+        name = str(plist_data["CFBundleName"])
+    else:
+        name = canonical_path.stem
+    if not name:
+        diagnostics.append("missing name")
+
+    version = ""
+    sp_version = str(sp_entry.get("version", "")).strip() if sp_entry else ""
+    if sp_version:
+        version = sp_version
+    elif plist_data.get("CFBundleShortVersionString"):
+        version = str(plist_data["CFBundleShortVersionString"]).strip()
+    elif plist_data.get("CFBundleVersion"):
+        version = str(plist_data["CFBundleVersion"]).strip()
+    if not version:
+        diagnostics.append("missing or empty version")
+
+    bundle_id: str | None = None
+    if sp_entry and sp_entry.get("bundle_id"):
+        bundle_id = str(sp_entry["bundle_id"])
+    elif plist_data.get("CFBundleIdentifier"):
+        bundle_id = str(plist_data["CFBundleIdentifier"])
+    if bundle_id is None:
+        diagnostics.append("missing bundle identifier")
+
+    obtained_from: str | None = None
+    if sp_entry and sp_entry.get("obtained_from"):
+        obtained_from = str(sp_entry["obtained_from"])
+
+    return ApplicationRecord(
+        name=name,
+        version=version,
+        path=raw_path,
+        canonical_path=canonical_path,
+        bundle_id=bundle_id,
+        obtained_from=obtained_from,
+        parent_bundle_path=parent_bundle_path,
+        app_store=resolve_app_store_evidence(canonical_path, obtained_from),
+        diagnostics=tuple(diagnostics),
+    )
+
+
+def discover_applications(
+    *,
+    roots: Sequence[Path] | None = None,
+    extra_roots: Sequence[str | Path] | None = None,
+    system_profiler_data: dict[str, Any] | None = None,
+    include_nested: bool = False,
+) -> list[ApplicationRecord]:
+    """Discover application bundle records under the given (or default) roots.
+
+    `roots`, when given, fully replaces default/configured root resolution --
+    the escape hatch tests use to run hermetically (e.g. `roots=[tmp_path]`),
+    never touching the real machine's /Applications or ~/Applications.
+    Otherwise resolve_discovery_roots(extra_roots) is used.
+
+    `system_profiler_data`, if given, only enriches records for bundles
+    already found by the filesystem walk -- it is never used to discover new
+    bundles beyond what the walk found itself. Discovery does not filter by
+    App Store / Homebrew / any evidence status: every in-scope bundle is
+    returned with its evidence attached, so `--all`-style consumers keep
+    every record. Filtering into an attention list is a later-phase concern.
+
+    Records are de-duplicated by identity_key (canonical_path, bundle_id) --
+    not name/version -- in first-seen order, so two apps sharing a display
+    name but differing in bundle_id or install location both survive as
+    distinct records.
+    """
+    active_roots = list(roots) if roots is not None else resolve_discovery_roots(extra_roots)
+    sp_index = _build_sp_index(system_profiler_data)
+
+    records: list[ApplicationRecord] = []
+    seen_identities: set[tuple[Path, str | None]] = set()
+
+    for root in active_roots:
+        try:
+            resolved_root = root.expanduser().resolve()
+        except OSError as e:
+            logging.debug("Could not resolve discovery root %s: %s", root, e)
+            continue
+
+        for raw_path in _walk_root(resolved_root, include_nested=include_nested):
+            canonical_path = raw_path.resolve()
+            parent_bundle_path = _nearest_parent_bundle(canonical_path, resolved_root)
+            record = _build_record(raw_path, canonical_path, parent_bundle_path, sp_index)
+
+            if record.identity_key in seen_identities:
+                logging.debug("Skipping duplicate application record: %s", record.identity_key)
+                continue
+            seen_identities.add(record.identity_key)
+            records.append(record)
+
+    return records

--- a/versiontracker/audit/homebrew.py
+++ b/versiontracker/audit/homebrew.py
@@ -1,0 +1,195 @@
+"""Exact Homebrew ownership resolution for the audit feature (Phase 2).
+
+Ownership is decided by joining each discovered bundle's canonical path
+against installed casks' `app` artifact targets -- never by fuzzy name
+matching (see versiontracker/apps/matcher.py:filter_out_brews for the
+fuzzy-matching approach this deliberately does not reuse). Cask
+"availability" (a matching cask exists but wasn't used to install this
+bundle) is a separate, later enrichment -- this module only ever produces
+MANAGED, NOT_AVAILABLE, or UNKNOWN, never AVAILABLE.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from versiontracker.audit.models import (
+    ApplicationRecord,
+    EvidenceConfidence,
+    EvidenceSource,
+    HomebrewEvidence,
+    HomebrewStatus,
+)
+from versiontracker.exceptions import DataParsingError, HomebrewError, NetworkError
+from versiontracker.exceptions import TimeoutError as VtTimeoutError
+from versiontracker.homebrew import get_brew_command
+from versiontracker.utils import run_command_secure
+
+_APP_ARTIFACT_KEY = "app"
+_TARGET_KEY = "target"
+
+
+@dataclasses.dataclass(frozen=True)
+class _InstalledCaskAppTarget:
+    """Internal: one installed cask's app-artifact ownership record."""
+
+    token: str
+    installed_version: str | None
+    artifact_target: Path
+    tap: str | None
+    auto_updates: bool
+
+
+def fetch_installed_casks(*, timeout: int = 60) -> list[dict[str, Any]]:
+    """Run `brew info --json=v2 --cask --installed` once and return the casks list.
+
+    `--cask` is added to the handoff spec's literal example command: it
+    skips formula data (confirmed identical `casks` shape either way, ~40%
+    smaller/faster on this machine) that this audit never looks at.
+
+    Raises HomebrewError/NetworkError/DataParsingError on any failure --
+    never returns a sentinel. apply_homebrew_evidence() is the single place
+    that catches these and degrades every record to UNKNOWN.
+    """
+    brew_path = get_brew_command()
+    cmd_args = [brew_path, "info", "--json=v2", "--cask", "--installed"]
+
+    try:
+        stdout, returncode = run_command_secure(cmd_args, timeout=timeout)
+    except VtTimeoutError as e:
+        raise NetworkError(f"Timed out running brew info --json=v2 --cask --installed: {e}") from e
+    except Exception as e:
+        # run_command_secure can surface a bare builtins.Exception when brew
+        # itself is missing/misconfigured: its own FileNotFoundError/
+        # PermissionError except clauses are bound to versiontracker's
+        # custom exception subclasses, not the plain builtins subprocess.Popen
+        # actually raises, so that case falls through to a bare Exception.
+        raise HomebrewError(f"Error running brew info --json=v2 --cask --installed: {e}") from e
+
+    if returncode != 0:
+        raise HomebrewError(f"brew info --json=v2 --cask --installed failed: {stdout}")
+
+    try:
+        data = json.loads(stdout)
+    except json.JSONDecodeError as e:
+        raise DataParsingError(f"Could not parse installed casks JSON: {e}") from e
+
+    casks = data.get("casks", [])
+    return casks if isinstance(casks, list) else []
+
+
+def _canonicalize_target(target: str) -> Path | None:
+    try:
+        return Path(target).expanduser().resolve()
+    except OSError as e:
+        logging.debug("Could not canonicalize cask artifact target %r: %s", target, e)
+        return None
+
+
+def build_artifact_index(casks: Sequence[dict[str, Any]]) -> dict[Path, _InstalledCaskAppTarget]:
+    """Map canonical app-artifact target path -> owning cask.
+
+    Only casks with at least one `app` artifact contribute -- casks without
+    one (fonts, CLI tools, pkg-only installers) are recorded nowhere, per
+    "record casks without an app artifact without guessing ownership".
+    Multi-app casks produce multiple separate artifact entries in Homebrew's
+    own JSON (never one entry listing multiple app names), so iterating
+    `artifacts` and reading each app-keyed entry's own `target` handles that
+    case with no special-casing.
+    """
+    index: dict[Path, _InstalledCaskAppTarget] = {}
+    for cask in casks:
+        token = cask.get("token")
+        if not token:
+            continue
+        for artifact in cask.get("artifacts", []):
+            if not isinstance(artifact, dict) or _APP_ARTIFACT_KEY not in artifact:
+                continue
+            target = artifact.get(_TARGET_KEY)
+            if not target:
+                continue
+            canonical = _canonicalize_target(target)
+            if canonical is None:
+                continue
+            if canonical in index:
+                logging.debug(
+                    "Cask '%s' artifact target %s collides with already-indexed cask '%s'; keeping first-seen",
+                    token,
+                    canonical,
+                    index[canonical].token,
+                )
+                continue
+            index[canonical] = _InstalledCaskAppTarget(
+                token=token,
+                installed_version=cask.get("installed"),
+                artifact_target=canonical,
+                tap=cask.get("tap"),
+                auto_updates=bool(cask.get("auto_updates", False)),
+            )
+    return index
+
+
+def resolve_homebrew_evidence(
+    record: ApplicationRecord, artifact_index: dict[Path, _InstalledCaskAppTarget]
+) -> HomebrewEvidence:
+    """Resolve Homebrew ownership for one record against a pre-built artifact index.
+
+    Only decides exact ownership (MANAGED) versus "not managed by an
+    installed cask" (NOT_AVAILABLE) -- it never claims a suitable cask
+    exists in the wider catalog when none is installed; that "availability"
+    check is a deliberately separate, later enrichment. This function never
+    sees a fetch failure (apply_homebrew_evidence() handles that upstream),
+    so it has no UNKNOWN branch of its own.
+    """
+    match = artifact_index.get(record.canonical_path)
+    if match is not None:
+        return HomebrewEvidence(
+            status=HomebrewStatus.MANAGED,
+            reason=f"Homebrew cask '{match.token}' owns this bundle via its app artifact target",
+            source=EvidenceSource.HOMEBREW_CLI,
+            matched_identifier=match.token,
+            confidence=EvidenceConfidence.HIGH,
+            installed_version=match.installed_version,
+            artifact_target=match.artifact_target,
+            cask_auto_updates=match.auto_updates,
+        )
+
+    return HomebrewEvidence(
+        status=HomebrewStatus.NOT_AVAILABLE,
+        reason=("No installed cask's app artifact targets this bundle path (the wider cask catalog was not searched)"),
+        source=EvidenceSource.HOMEBREW_CLI,
+        confidence=EvidenceConfidence.HIGH,
+    )
+
+
+def apply_homebrew_evidence(records: Sequence[ApplicationRecord]) -> list[ApplicationRecord]:
+    """Resolve and attach Homebrew evidence to each record, returning new records.
+
+    Fetches the installed-cask list and builds the artifact index once. If
+    that fails for any reason (Homebrew missing, command failure, malformed
+    JSON), every record gets HomebrewStatus.UNKNOWN -- never NOT_AVAILABLE,
+    per "if Homebrew is missing or the command fails, set unknown, not
+    not_managed."
+    """
+    try:
+        casks = fetch_installed_casks()
+        artifact_index = build_artifact_index(casks)
+    except (HomebrewError, NetworkError, DataParsingError) as e:
+        logging.warning("Homebrew ownership resolution unavailable: %s", e)
+        unknown = HomebrewEvidence(
+            status=HomebrewStatus.UNKNOWN,
+            reason="Could not determine installed Homebrew casks",
+            source=EvidenceSource.HOMEBREW_CLI,
+            confidence=EvidenceConfidence.NONE,
+            error=str(e),
+        )
+        return [dataclasses.replace(record, homebrew=unknown) for record in records]
+
+    return [
+        dataclasses.replace(record, homebrew=resolve_homebrew_evidence(record, artifact_index)) for record in records
+    ]

--- a/versiontracker/audit/models.py
+++ b/versiontracker/audit/models.py
@@ -1,0 +1,252 @@
+"""Data models for the unmanaged macOS application audit feature.
+
+Shared evidence vocabulary and the ApplicationRecord shape. AppStoreEvidence
+is resolved during discovery (see discovery.py::resolve_app_store_evidence);
+HomebrewEvidence, AutoUpdateEvidence, and BlocklistEvidence are resolved by
+homebrew.py, auto_update.py, and blocklist.py respectively. Each Evidence
+type ships its own `.not_evaluated()` default so a record can be partially
+resolved (e.g. by a fresh discover_applications() call, before any resolver
+has run) without ApplicationRecord's shape changing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+
+class EvidenceSource(Enum):
+    """Where a piece of evidence was derived from."""
+
+    SYSTEM_PROFILER = "system_profiler"
+    FILESYSTEM = "filesystem"
+    HOMEBREW_CLI = "homebrew_cli"
+    CONFIG = "config"
+    NOT_EVALUATED = "not_evaluated"
+
+
+class EvidenceConfidence(Enum):
+    """Confidence attached to a resolved piece of evidence."""
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    NONE = "none"
+
+
+class AppStoreStatus(Enum):
+    """App Store management status for an application bundle."""
+
+    APP_STORE = "app_store"
+    NOT_APP_STORE = "not_app_store"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class AppStoreEvidence:
+    """Evidence for whether an application is App Store-managed."""
+
+    status: AppStoreStatus
+    reason: str
+    source: EvidenceSource
+    matched_identifier: str | None = None
+    confidence: EvidenceConfidence = EvidenceConfidence.NONE
+    error: str | None = None
+
+
+class HomebrewStatus(Enum):
+    """Homebrew ownership status for an application bundle.
+
+    Resolved starting in a later phase; Phase 1 records only carry
+    NOT_EVALUATED (see HomebrewEvidence.not_evaluated).
+    """
+
+    MANAGED = "managed"
+    AVAILABLE = "available"
+    NOT_AVAILABLE = "not_available"
+    UNKNOWN = "unknown"
+    NOT_EVALUATED = "not_evaluated"
+
+
+@dataclass(frozen=True)
+class HomebrewEvidence:
+    """Evidence for Homebrew ownership/availability of an application."""
+
+    status: HomebrewStatus
+    reason: str
+    source: EvidenceSource
+    matched_identifier: str | None = None
+    confidence: EvidenceConfidence = EvidenceConfidence.NONE
+    error: str | None = None
+    installed_version: str | None = None
+    artifact_target: Path | None = None
+    cask_auto_updates: bool | None = None
+
+    @classmethod
+    def not_evaluated(cls) -> HomebrewEvidence:
+        """Return the Phase 1 placeholder: Homebrew resolution hasn't run yet."""
+        return cls(
+            status=HomebrewStatus.NOT_EVALUATED,
+            reason="Homebrew ownership resolution runs in a later phase",
+            source=EvidenceSource.NOT_EVALUATED,
+        )
+
+
+class AutoUpdateStatus(Enum):
+    """Auto-update capability status for an application bundle.
+
+    Resolved starting in a later phase; Phase 1 records only carry
+    NOT_EVALUATED (see AutoUpdateEvidence.not_evaluated).
+    """
+
+    ENABLED = "enabled"
+    CAPABLE = "capable"
+    NONE_DETECTED = "none_detected"
+    UNKNOWN = "unknown"
+    NOT_EVALUATED = "not_evaluated"
+
+
+class AutoUpdateMechanism(Enum):
+    """Which local mechanism contributed positive auto-update evidence."""
+
+    SPARKLE_FRAMEWORK = "sparkle_framework"
+    SQUIRREL_FRAMEWORK = "squirrel_framework"
+    ELECTRON_UPDATER_YML = "electron_updater_yml"
+    MOZILLA_UPDATER = "mozilla_updater"
+    VENDOR_LAUNCH_AGENT = "vendor_launch_agent"
+    HOMEBREW_CASK_AUTO_UPDATES = "homebrew_cask_auto_updates"
+
+
+@dataclass(frozen=True)
+class AutoUpdateEvidence:
+    """Evidence for an application's automatic-update capability."""
+
+    status: AutoUpdateStatus
+    reason: str
+    source: EvidenceSource
+    matched_identifier: str | None = None
+    confidence: EvidenceConfidence = EvidenceConfidence.NONE
+    error: str | None = None
+    mechanisms: tuple[AutoUpdateMechanism, ...] = ()
+
+    @classmethod
+    def not_evaluated(cls) -> AutoUpdateEvidence:
+        """Return the Phase 1 placeholder: auto-update resolution hasn't run yet."""
+        return cls(
+            status=AutoUpdateStatus.NOT_EVALUATED,
+            reason="Auto-update capability resolution runs in a later phase",
+            source=EvidenceSource.NOT_EVALUATED,
+        )
+
+
+class BlocklistStatus(Enum):
+    """Blocklist status for an application bundle.
+
+    Resolved starting in a later phase; Phase 1 records only carry
+    NOT_EVALUATED (see BlocklistEvidence.not_evaluated).
+    """
+
+    BLOCKED = "blocked"
+    NOT_BLOCKED = "not_blocked"
+    UNKNOWN = "unknown"
+    NOT_EVALUATED = "not_evaluated"
+
+
+class BlocklistMatchKind(Enum):
+    """Which identity signal a blocklist match was decided by."""
+
+    CANONICAL_PATH = "canonical_path"
+    BUNDLE_ID = "bundle_id"
+    HOMEBREW_TOKEN = "homebrew_token"
+    DISPLAY_NAME = "display_name"
+
+
+@dataclass(frozen=True)
+class BlocklistEvidence:
+    """Evidence for whether an application is blocklisted."""
+
+    status: BlocklistStatus
+    reason: str
+    source: EvidenceSource
+    matched_identifier: str | None = None
+    confidence: EvidenceConfidence = EvidenceConfidence.NONE
+    error: str | None = None
+    matched_by: BlocklistMatchKind | None = None
+
+    @classmethod
+    def not_evaluated(cls) -> BlocklistEvidence:
+        """Return the Phase 1 placeholder: blocklist resolution hasn't run yet."""
+        return cls(
+            status=BlocklistStatus.NOT_EVALUATED,
+            reason="Blocklist resolution runs in a later phase",
+            source=EvidenceSource.NOT_EVALUATED,
+        )
+
+
+@dataclass(frozen=True)
+class ApplicationRecord:
+    """Identity-preserving record for one discovered application bundle."""
+
+    name: str
+    version: str
+    path: Path
+    canonical_path: Path
+    bundle_id: str | None
+    obtained_from: str | None
+    parent_bundle_path: Path | None
+
+    app_store: AppStoreEvidence
+    homebrew: HomebrewEvidence = field(default_factory=HomebrewEvidence.not_evaluated)
+    auto_update: AutoUpdateEvidence = field(default_factory=AutoUpdateEvidence.not_evaluated)
+    blocklist: BlocklistEvidence = field(default_factory=BlocklistEvidence.not_evaluated)
+
+    diagnostics: tuple[str, ...] = ()
+
+    @property
+    def identity_key(self) -> tuple[Path, str | None]:
+        """Stable identity used for de-duplication and future cross-resolver joins."""
+        return (self.canonical_path, self.bundle_id)
+
+    @property
+    def is_nested_component(self) -> bool:
+        """True if this bundle was found nested inside another bundle's Contents/."""
+        return self.parent_bundle_path is not None
+
+
+class AuditBucket(Enum):
+    """Which section of the audit output an application belongs to."""
+
+    ATTENTION = "attention"
+    UNKNOWN = "unknown"
+    MANAGED = "managed"
+
+
+@dataclass(frozen=True)
+class AuditClassification:
+    """The bucket a record was sorted into, and a human-readable explanation."""
+
+    bucket: AuditBucket
+    why: str
+
+
+@dataclass(frozen=True)
+class ClassifiedApplication:
+    """One application paired with its audit classification."""
+
+    record: ApplicationRecord
+    classification: AuditClassification
+
+
+@dataclass(frozen=True)
+class AuditResult:
+    """The full output of one audit run.
+
+    `summary` always reflects the entire discovered set, regardless of any
+    filtering later applied to `applications` (see service.py::filter_result)
+    -- a filtered view should still be able to report how many applications
+    exist in the buckets it isn't showing.
+    """
+
+    applications: tuple[ClassifiedApplication, ...]
+    summary: dict[str, int]

--- a/versiontracker/audit/rendering.py
+++ b/versiontracker/audit/rendering.py
@@ -1,0 +1,236 @@
+"""Terminal rendering and versioned JSON/YAML/CSV export for audit results.
+
+Every function here is pure -- takes an AuditResult, returns a str. None of
+them print anything; printing is exclusively versiontracker.handlers.
+audit_handlers.handle_audit()'s job, extending the Phase 1-3 rule that
+library code never touches stdout into Phase 4.
+"""
+
+from __future__ import annotations
+
+import csv
+import dataclasses
+import io
+import json
+from collections.abc import Sequence
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import yaml
+from tabulate import tabulate
+
+from versiontracker.audit.models import (
+    AppStoreEvidence,
+    AuditBucket,
+    AuditResult,
+    AutoUpdateEvidence,
+    BlocklistEvidence,
+    ClassifiedApplication,
+    HomebrewEvidence,
+)
+
+_SCHEMA_VERSION = 1
+_EVIDENCE_GROUPS: tuple[tuple[str, type], ...] = (
+    ("app_store", AppStoreEvidence),
+    ("homebrew", HomebrewEvidence),
+    ("auto_update", AutoUpdateEvidence),
+    ("blocklist", BlocklistEvidence),
+)
+
+
+def _to_json_safe(value: Any) -> Any:
+    """Recursively convert dataclasses/Enums/Paths/tuples into JSON-safe values.
+
+    Handles ApplicationRecord and every Evidence type generically (via
+    dataclasses.fields()) rather than hand-listing each type's fields --
+    the field sets genuinely differ per Evidence type (installed_version/
+    artifact_target/cask_auto_updates on Homebrew, mechanisms on
+    auto-update, matched_by on blocklist), and a generic walk can't drift
+    out of sync when a new field is added to any of them.
+    """
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return {f.name: _to_json_safe(getattr(value, f.name)) for f in dataclasses.fields(value)}
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, tuple | list):
+        return [_to_json_safe(v) for v in value]
+    return value
+
+
+def _result_to_dict(result: AuditResult) -> dict[str, Any]:
+    """Shared builder for render_json/render_yaml.
+
+    Keeps the two formats from ever drifting apart, since both call this
+    exactly once.
+    """
+    applications = []
+    for app in result.applications:
+        app_dict = _to_json_safe(app.record)
+        app_dict["classification"] = app.classification.bucket.value
+        app_dict["why"] = app.classification.why
+        applications.append(app_dict)
+    return {
+        "schema_version": _SCHEMA_VERSION,
+        "summary": dict(result.summary),
+        "applications": applications,
+    }
+
+
+def render_json(result: AuditResult) -> str:
+    """Full evidence for every application, regardless of --explain.
+
+    The spec states this as an unconditional export property, and keeping
+    the shape independent of --explain keeps the versioned schema stable
+    for any script parsing it.
+    """
+    return json.dumps(_result_to_dict(result), indent=2)
+
+
+def render_yaml(result: AuditResult) -> str:
+    """Same shape as render_json via the same shared builder."""
+    return yaml.safe_dump(_result_to_dict(result), sort_keys=False, default_flow_style=False)
+
+
+def _csv_fieldnames() -> list[str]:
+    """Derived from the model classes themselves, not from any instance.
+
+    This way an empty result still produces a correct header-only CSV.
+    """
+    fields = [
+        "name",
+        "version",
+        "path",
+        "canonical_path",
+        "bundle_id",
+        "obtained_from",
+        "parent_bundle_path",
+        "diagnostics",
+        "classification",
+        "why",
+    ]
+    for group_name, evidence_cls in _EVIDENCE_GROUPS:
+        fields.extend(f"{group_name}_{f.name}" for f in dataclasses.fields(evidence_cls))
+    return fields
+
+
+def _csv_cell(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, list):
+        return ";".join(str(v) for v in value)
+    return str(value)
+
+
+def _flatten_application(app: ClassifiedApplication) -> dict[str, str]:
+    record_dict = _to_json_safe(app.record)
+    row: dict[str, str] = {
+        "name": _csv_cell(record_dict["name"]),
+        "version": _csv_cell(record_dict["version"]),
+        "path": _csv_cell(record_dict["path"]),
+        "canonical_path": _csv_cell(record_dict["canonical_path"]),
+        "bundle_id": _csv_cell(record_dict["bundle_id"]),
+        "obtained_from": _csv_cell(record_dict["obtained_from"]),
+        "parent_bundle_path": _csv_cell(record_dict["parent_bundle_path"]),
+        "diagnostics": _csv_cell(record_dict["diagnostics"]),
+        "classification": app.classification.bucket.value,
+        "why": app.classification.why,
+    }
+    for group_name, _evidence_cls in _EVIDENCE_GROUPS:
+        for field_name, value in record_dict[group_name].items():
+            row[f"{group_name}_{field_name}"] = _csv_cell(value)
+    return row
+
+
+def render_csv(result: AuditResult) -> str:
+    """One row per application, one column per evidence field, prefixed by group.
+
+    E.g. app_store_status, homebrew_installed_version, .... No standard
+    place for schema_version in CSV -- the column list itself is the
+    contract.
+    """
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=_csv_fieldnames())
+    writer.writeheader()
+    for app in result.applications:
+        writer.writerow(_flatten_application(app))
+    return output.getvalue()
+
+
+def _render_compact_table(applications: Sequence[ClassifiedApplication]) -> str:
+    rows = [
+        [
+            app.record.name,
+            app.record.version,
+            app.record.app_store.status.value,
+            app.record.homebrew.status.value,
+            app.record.auto_update.status.value,
+            app.classification.why,
+        ]
+        for app in applications
+    ]
+    return str(
+        tabulate(
+            rows, headers=["Application", "Version", "App Store", "Homebrew", "Auto-update", "Why"], tablefmt="pretty"
+        )
+    )
+
+
+def _render_explain_block(app: ClassifiedApplication) -> str:
+    record = app.record
+    lines = [f"{record.name} ({record.version}) -- {app.classification.bucket.value}: {app.classification.why}"]
+    for label, evidence in (
+        ("App Store", record.app_store),
+        ("Homebrew", record.homebrew),
+        ("Auto-update", record.auto_update),
+        ("Blocklist", record.blocklist),
+    ):
+        lines.append(
+            f"  {label}: {evidence.status.value} -- {evidence.reason} "
+            f"[source={evidence.source.value}, confidence={evidence.confidence.value}]"
+        )
+    return "\n".join(lines)
+
+
+def _render_section(title: str, applications: Sequence[ClassifiedApplication], *, explain: bool) -> str:
+    if explain:
+        body = "\n".join(_render_explain_block(app) for app in applications)
+    else:
+        body = _render_compact_table(applications)
+    return f"{title}\n{body}"
+
+
+def _render_summary(summary: dict[str, int]) -> str:
+    return (
+        "Summary\n"
+        f"  Total: {summary['total']}  Attention: {summary['attention']}  "
+        f"Unknown: {summary['unknown']}  Managed: {summary['managed']}"
+    )
+
+
+def render_terminal(result: AuditResult, *, explain: bool) -> str:
+    """Render sections: attention / unknown / managed / summary.
+
+    Each section is shown exactly when `result` (already filtered by
+    service.py::filter_result) contains an application for it. This
+    function only groups whatever it's given by each application's own
+    classification; it never re-applies filtering itself, so e.g.
+    `--status managed` correctly shows every managed application without
+    also needing `--all`.
+    """
+    attention = [app for app in result.applications if app.classification.bucket == AuditBucket.ATTENTION]
+    unknown = [app for app in result.applications if app.classification.bucket == AuditBucket.UNKNOWN]
+    managed = [app for app in result.applications if app.classification.bucket == AuditBucket.MANAGED]
+
+    sections: list[str] = []
+    if attention:
+        sections.append(_render_section("Needs manual management", attention, explain=explain))
+    if unknown:
+        sections.append(_render_section("Needs review (unknown evidence)", unknown, explain=explain))
+    if managed:
+        sections.append(_render_section("Managed", managed, explain=explain))
+    sections.append(_render_summary(result.summary))
+
+    return "\n\n".join(sections)

--- a/versiontracker/audit/service.py
+++ b/versiontracker/audit/service.py
@@ -1,0 +1,185 @@
+"""Audit orchestration: discover once, resolve every evidence axis, classify.
+
+`run_audit()` is the single entry point that wires Phases 1-3 together in
+the order that matters: discovery (with real system_profiler enrichment)
+first, then Homebrew ownership, then blocklist and auto-update -- both of
+which read already-resolved Homebrew evidence off each record, so Homebrew
+must land before either. Blocklist and auto-update don't read each other,
+so their relative order doesn't matter.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from versiontracker.audit.auto_update import apply_auto_update_evidence
+from versiontracker.audit.blocklist import apply_blocklist_evidence
+from versiontracker.audit.discovery import discover_applications
+from versiontracker.audit.homebrew import apply_homebrew_evidence
+from versiontracker.audit.models import (
+    ApplicationRecord,
+    AppStoreEvidence,
+    AppStoreStatus,
+    AuditBucket,
+    AuditClassification,
+    AuditResult,
+    AutoUpdateEvidence,
+    AutoUpdateStatus,
+    BlocklistEvidence,
+    BlocklistStatus,
+    ClassifiedApplication,
+    HomebrewEvidence,
+    HomebrewStatus,
+)
+from versiontracker.config import get_config
+from versiontracker.utils import get_json_data
+
+_UNKNOWN_STATUS_VALUES = frozenset({"unknown", "not_evaluated"})
+
+
+def _fetch_system_profiler_data() -> dict[str, Any] | None:
+    """Fetch real system_profiler data for App Store obtained_from enrichment.
+
+    Never raises -- returns None on any failure, which discover_applications()
+    already handles gracefully (App Store evidence falls back to the
+    MASReceipt-only signal, per discovery.py's own resolve_app_store_evidence
+    truth table). Deliberately catches Exception broadly rather than a
+    curated tuple: the same lesson already learned for plistlib (a narrower
+    guess at "every way this can fail" previously missed a real exception
+    type) applies equally to a subprocess+JSON fetch.
+    """
+    try:
+        command = get_config().get("system_profiler_cmd", "system_profiler -json SPApplicationsDataType")
+        return get_json_data(command)
+    except Exception as e:
+        logging.warning("Could not fetch system_profiler data for App Store enrichment: %s", e)
+        return None
+
+
+def classify_record(record: ApplicationRecord) -> AuditClassification:
+    """Classify one record into attention / unknown / managed.
+
+    Any evidence axis with status "unknown" or "not_evaluated" (checking
+    the string value works uniformly across all four distinct enums, each
+    has a member literally valued "unknown") puts the record in UNKNOWN,
+    unconditionally -- even alongside a confident BLOCKED on a different
+    axis, per the spec's unqualified "applications with incomplete or
+    failed evidence belong in a separate unknown/needs_review section."
+
+    Otherwise ATTENTION requires all four signals to be quiet:
+    app_store != APP_STORE, homebrew != MANAGED (not "== NOT_AVAILABLE" --
+    a future AVAILABLE result must stay attention-eligible too, since only
+    MANAGED denotes real ownership; AVAILABLE is a remediation suggestion,
+    not exclusion), auto_update not in (ENABLED, CAPABLE), blocklist !=
+    BLOCKED. Otherwise MANAGED, with `why` naming every excluding signal.
+    """
+    axes: dict[str, AppStoreEvidence | HomebrewEvidence | AutoUpdateEvidence | BlocklistEvidence] = {
+        "app_store": record.app_store,
+        "homebrew": record.homebrew,
+        "auto_update": record.auto_update,
+        "blocklist": record.blocklist,
+    }
+    unknown_axes = [name for name, evidence in axes.items() if evidence.status.value in _UNKNOWN_STATUS_VALUES]
+    if unknown_axes:
+        parts = []
+        for name in unknown_axes:
+            evidence = axes[name]
+            detail = f"{name}: {evidence.status.value}"
+            if evidence.error:
+                detail += f" ({evidence.error})"
+            parts.append(detail)
+        return AuditClassification(bucket=AuditBucket.UNKNOWN, why="Evidence incomplete: " + "; ".join(parts))
+
+    is_app_store = record.app_store.status == AppStoreStatus.APP_STORE
+    is_homebrew_managed = record.homebrew.status == HomebrewStatus.MANAGED
+    is_auto_updating = record.auto_update.status in (AutoUpdateStatus.ENABLED, AutoUpdateStatus.CAPABLE)
+    is_blocklisted = record.blocklist.status == BlocklistStatus.BLOCKED
+
+    if not (is_app_store or is_homebrew_managed or is_auto_updating or is_blocklisted):
+        why = "Not managed by the App Store, Homebrew, a local auto-updater, or the blocklist"
+        if record.homebrew.status == HomebrewStatus.AVAILABLE:
+            why += f" (Homebrew: {record.homebrew.reason} -- remediation suggestion, not ownership)"
+        return AuditClassification(bucket=AuditBucket.ATTENTION, why=why)
+
+    reasons = []
+    if is_app_store:
+        reasons.append("managed by the App Store")
+    if is_homebrew_managed:
+        reasons.append(f"managed by Homebrew ({record.homebrew.matched_identifier})")
+    if is_auto_updating:
+        reasons.append(f"has a local auto-update mechanism ({record.auto_update.status.value})")
+    if is_blocklisted:
+        matched_by = record.blocklist.matched_by.value if record.blocklist.matched_by else "unknown signal"
+        reasons.append(f"blocklisted (matched by {matched_by})")
+    # Capitalize only the first character -- str.capitalize() would also
+    # lowercase the rest of the string, destroying "App Store"'s and
+    # "Homebrew"'s intentional capitalization.
+    combined = "; ".join(reasons)
+    why = combined[0].upper() + combined[1:] if combined else combined
+    return AuditClassification(bucket=AuditBucket.MANAGED, why=why)
+
+
+def _build_summary(applications: Sequence[ClassifiedApplication]) -> dict[str, int]:
+    summary = {"total": len(applications), "attention": 0, "unknown": 0, "managed": 0}
+    for app in applications:
+        summary[app.classification.bucket.value] += 1
+    return summary
+
+
+def run_audit(
+    *,
+    roots: Sequence[Path] | None = None,
+    extra_roots: Sequence[str | Path] | None = None,
+    system_profiler_data: dict[str, Any] | None = None,
+    launch_agent_dirs: Sequence[Path] | None = None,
+    blocklist_entries: Sequence[str] | None = None,
+) -> AuditResult:
+    """Discover once, resolve every evidence axis, classify, return a structured result.
+
+    `system_profiler_data=None` means "fetch the real thing" (via
+    _fetch_system_profiler_data(), degrading to None on failure) -- tests
+    that want to exercise the no-system-profiler-data path must patch
+    _fetch_system_profiler_data itself, not rely on passing None, since None
+    is now the "use the real default" sentinel, consistent with every other
+    parameter here.
+    """
+    sp_data = system_profiler_data if system_profiler_data is not None else _fetch_system_profiler_data()
+    records = discover_applications(roots=roots, extra_roots=extra_roots, system_profiler_data=sp_data)
+
+    # Homebrew must resolve before BOTH blocklist (its cask-token tier reads
+    # record.homebrew.matched_identifier) and auto-update
+    # (_apply_homebrew_cask_supplement reads record.homebrew.status /
+    # .cask_auto_updates / .matched_identifier). Blocklist and auto-update
+    # don't read each other, so their relative order doesn't matter.
+    records = apply_homebrew_evidence(records)
+    records = apply_blocklist_evidence(records, blocklist_entries)
+    records = apply_auto_update_evidence(records, launch_agent_dirs=launch_agent_dirs)
+
+    applications = tuple(
+        ClassifiedApplication(record=record, classification=classify_record(record))
+        for record in sorted(records, key=lambda r: (r.name.lower(), r.canonical_path))
+    )
+    return AuditResult(applications=applications, summary=_build_summary(applications))
+
+
+def filter_result(result: AuditResult, *, show_all: bool, status: AuditBucket | None) -> AuditResult:
+    """Select which applications to show; `summary` always reflects the full set.
+
+    show_all=True: no filtering. status=X: exactly that bucket. Neither:
+    ATTENTION union UNKNOWN -- the spec's default 3-section terminal view
+    (Needs manual management / Needs review / Summary).
+    """
+    if show_all:
+        selected = result.applications
+    elif status is not None:
+        selected = tuple(app for app in result.applications if app.classification.bucket == status)
+    else:
+        selected = tuple(
+            app
+            for app in result.applications
+            if app.classification.bucket in (AuditBucket.ATTENTION, AuditBucket.UNKNOWN)
+        )
+    return AuditResult(applications=selected, summary=result.summary)

--- a/versiontracker/cli.py
+++ b/versiontracker/cli.py
@@ -25,6 +25,9 @@ Examples:
   versiontracker --brews             List Homebrew casks
   versiontracker --recom             Recommend Homebrew casks for installed apps
   versiontracker --check-outdated    Check for outdated applications
+  versiontracker --audit             Audit apps not managed by App Store/Homebrew/auto-updater
+  versiontracker --audit --all --explain --export json
+                                      Full audit evidence as machine-readable JSON
 
 For more information, visit: https://github.com/docdyhr/versiontracker
         """,
@@ -75,6 +78,11 @@ For more information, visit: https://github.com/docdyhr/versiontracker
         action="store_true",
         help="Check for outdated applications",
     )
+    action_group.add_argument(
+        "--audit",
+        action="store_true",
+        help="Audit applications not managed by the App Store, Homebrew, or a local auto-updater",
+    )
 
     # Auto-update management (mutually exclusive)
     auto_update_group = parser.add_mutually_exclusive_group()
@@ -109,6 +117,25 @@ For more information, visit: https://github.com/docdyhr/versiontracker
         dest="only_auto_updates",
         action="store_true",
         help="Only show applications that have auto-updates enabled",
+    )
+
+    # Audit view options (used with --audit)
+    audit_view_group = parser.add_mutually_exclusive_group()
+    audit_view_group.add_argument(
+        "--all",
+        action="store_true",
+        help="Show every audited application, not just those needing attention (with --audit)",
+    )
+    audit_view_group.add_argument(
+        "--status",
+        choices=["attention", "unknown", "managed"],
+        metavar="STATUS",
+        help="Show only applications in this audit status (with --audit)",
+    )
+    parser.add_argument(
+        "--explain",
+        action="store_true",
+        help="Show full evidence per application instead of a compact table (with --audit)",
     )
 
     # Service management options

--- a/versiontracker/handlers/__init__.py
+++ b/versiontracker/handlers/__init__.py
@@ -8,6 +8,7 @@ design principle for better separation of concerns.
 
 # Import handlers from submodules for easier access
 from versiontracker.handlers.app_handlers import handle_list_apps
+from versiontracker.handlers.audit_handlers import handle_audit
 from versiontracker.handlers.auto_update_handlers import (
     handle_blacklist_auto_updates,
     handle_list_auto_updates,
@@ -47,6 +48,7 @@ except ImportError:
     _MACOS_HANDLERS_AVAILABLE = False
 
 __all__ = [
+    "handle_audit",
     "handle_list_apps",
     "handle_list_brews",
     "handle_brew_recommendations",

--- a/versiontracker/handlers/audit_handlers.py
+++ b/versiontracker/handlers/audit_handlers.py
@@ -1,0 +1,111 @@
+"""Audit command handler for VersionTracker.
+
+Thin wrapper around versiontracker.audit.service/rendering: parses CLI
+options, runs the audit, and either prints terminal sections or, when
+exporting, prints *only* the rendered export string. Unlike every other
+existing handler (which prints a table unconditionally and then, separately,
+export output if requested), this one never prints both -- exported stdout
+must contain nothing but the requested data.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from versiontracker.audit import (
+    AuditBucket,
+    AuditResult,
+    filter_result,
+    render_csv,
+    render_json,
+    render_terminal,
+    render_yaml,
+    run_audit,
+)
+from versiontracker.config import get_config
+from versiontracker.ui import create_progress_bar
+
+_RENDERERS = {"json": render_json, "yaml": render_yaml, "csv": render_csv}
+
+
+def _parse_additional_dirs(options: Any) -> list[str] | None:
+    """Parse --additional-dirs as colon-separated, per its documented help text.
+
+    Matches discovery.py's extra_roots convention -- NOT the comma-split
+    app_handlers.py's own (dead, unused) --additional-dirs handling uses.
+    """
+    raw = getattr(options, "additional_dirs", None)
+    if not raw:
+        return None
+    return [entry for entry in raw.split(":") if entry]
+
+
+def _merge_blocklist_entries(options: Any) -> list[str]:
+    """Merge configured blocklist entries with any CLI-supplied ones.
+
+    Deliberately merges rather than overrides, per the spec's "prefer
+    merge semantics for an audit filter." A divergence from
+    app_handlers.py::_apply_blocklist_filtering()'s override-via-temp-config
+    behavior, which stays untouched (out of scope for this feature).
+    """
+    entries = list(get_config().get_blocklist())
+    for option_name in ("blocklist", "blacklist"):
+        raw = getattr(options, option_name, None)
+        if not raw:
+            continue
+        for entry in raw.split(","):
+            entry = entry.strip()
+            if entry and entry not in entries:
+                entries.append(entry)
+    return entries
+
+
+def _handle_export(result: AuditResult, export_format: str, output_file: str | None) -> int:
+    renderer = _RENDERERS.get(export_format.lower())
+    if renderer is None:
+        print(f"Unsupported export format: {export_format}")
+        return 1
+
+    content = renderer(result)
+
+    if output_file:
+        try:
+            with open(output_file, "w") as f:
+                f.write(content)
+        except OSError as e:
+            print(f"Error: Failed to write to {output_file}: {e}")
+            return 1
+        print(
+            create_progress_bar().color("green")(f"Exported {len(result.applications)} applications to {output_file}")
+        )
+        return 0
+
+    # Nothing else may print to stdout in this branch -- this is the
+    # concrete mechanism that keeps exported output machine-parseable.
+    print(content)
+    return 0
+
+
+def handle_audit(options: Any) -> int:
+    """Handle the --audit action.
+
+    Returns:
+        int: Exit code (0 for success, non-zero for failure)
+    """
+    extra_roots = _parse_additional_dirs(options)
+    blocklist_entries = _merge_blocklist_entries(options)
+
+    result = run_audit(extra_roots=extra_roots, blocklist_entries=blocklist_entries)
+
+    status_option = getattr(options, "status", None)
+    status = AuditBucket(status_option) if status_option else None
+    show_all = bool(getattr(options, "all", False))
+    result = filter_result(result, show_all=show_all, status=status)
+
+    export_format = getattr(options, "export_format", None)
+    if export_format:
+        return _handle_export(result, export_format, getattr(options, "output_file", None))
+
+    explain = bool(getattr(options, "explain", False))
+    print(render_terminal(result, explain=explain))
+    return 0

--- a/versiontracker/handlers/macos_handlers.py
+++ b/versiontracker/handlers/macos_handlers.py
@@ -39,7 +39,7 @@ def handle_install_service(options: Namespace) -> int:
         interval_hours = getattr(options, "service_interval", 24)
 
         # Prepare command arguments
-        command_args = ["--outdated", "--no-progress"]
+        command_args = ["--check-outdated", "--no-progress"]
 
         # Install the service
         success = install_scheduled_checker(interval_hours, command_args)

--- a/versiontracker/menubar_app.py
+++ b/versiontracker/menubar_app.py
@@ -80,8 +80,8 @@ class MenubarApp:
 
         # Map menu choices to versiontracker commands
         commands = {
-            "Check for Updates": ["--outdated", "--notify"],
-            "Show Outdated Apps": ["--outdated"],
+            "Check for Updates": ["--check-outdated"],
+            "Show Outdated Apps": ["--check-outdated"],
             "Show All Apps": ["--apps"],
             "Show Homebrew Casks": ["--brews"],
             "Install Service": ["--install-service"],


### PR DESCRIPTION
## Summary

Implements `versiontracker --audit`: answers "which user-facing applications
are not managed by the App Store, not owned by Homebrew, have no confirmed
local auto-update mechanism, and aren't blocklisted?" with full evidence per
signal (status, reason, confidence, source) rather than a bare yes/no. A
failed lookup is always reported as `unknown`, never silently collapsed into
a negative.

Full spec: a detailed handoff document specifying a 6-phase implementation
(this PR covers Phases 1-5; Phase 6 -- NLP/Swift GUI consumers -- is
explicitly optional and deferred until this backend/CLI contract has settled).

Built and verified across 5 phases, each with an independent design review
and a live sanity check against this machine's real `/Applications` before
moving to the next:

1. **Models + identity-preserving discovery** -- filesystem-walk-based
   discovery (not a `system_profiler`-JSON filter), so newly-configured
   additional directories are found even before Spotlight indexes them.
2. **Exact Homebrew ownership + blocklist identity** -- joins bundles to
   `brew info --json=v2 --cask --installed` app-artifact target paths, zero
   fuzzy matching; blocklist matches by canonical path / bundle ID / cask
   token / display name.
3. **Local auto-update evidence** -- five independent probes (Sparkle,
   Squirrel, electron-updater, Mozilla updater, vendor LaunchAgents)
   aggregated into one result.
4. **CLI wiring, terminal renderer, JSON/YAML/CSV export** -- `--audit`,
   `--all`, `--status {attention,unknown,managed}`, `--explain`; versioned
   JSON/YAML schema; CSV export.
5. **Regression tests + documentation** -- an end-to-end golden fixture
   proving the resolvers compose correctly, targeted failure-injection
   tests, and full documentation.

### Real bugs found and fixed along the way

Each phase's design review (and, in three cases, the live sanity pass
itself) caught genuine bugs before or shortly after they shipped -- these
are documented in detail per-phase in `TODO.md`, but the headline ones:

- A classification condition that would have wrongly excluded a future
  Homebrew `available` result from the attention view.
- `run_audit()` never actually fetching real `system_profiler` data, which
  would have silently degraded App Store detection to medium-confidence on
  every real run.
- `plistlib.load()` raising `xml.parsers.expat.ExpatError` on a genuinely
  malformed plist (found via a real corrupt LaunchAgent on this machine) --
  not caught by the `(OSError, ValueError, InvalidFileException)` tuple
  either resolver originally used.
- `render_terminal()` gating its "Managed" section behind `--all` even
  though `filter_result()` had already scoped the result to exactly the
  requested bucket -- `--status managed` silently returned zero rows.
- Two real, live, silently-shipping bugs unrelated to the audit feature
  itself, found while sweeping for stale `--outdated` references:
  `menubar_app.py` and `handlers/macos_handlers.py` both hard-coded a CLI
  flag that was never real (`--outdated` -- the actual flag is
  `--check-outdated`). Every menubar "Check for Updates" click and every
  `--install-service` scheduled background check has been failing silently
  since introduction. `tests/handlers/test_macos_handlers.py` had a test
  asserting the broken value as *correct*; fixed alongside the bug.

### Known, confirmed, separate bugs found but deliberately not fixed here

Documented in `TODO.md` for a future, separate decision:

- `--strict-recommend` is non-functional as documented (`filter_out_brews`'s
  `strict_mode` parameter has zero effect on its return value -- a
  pre-existing bug in unrelated legacy code, not something this PR's scope
  covers).
- `HomebrewStatus.AVAILABLE` is a phantom status no resolver produces yet
  (cask availability was deliberately deferred as a later enrichment).

## Test plan

- [x] `ruff check versiontracker tests` -- clean
- [x] `mypy versiontracker` -- at the established 63-pre-existing-error
      baseline (+1 known `tabulate`-stubs gap now also in the new
      `rendering.py`, same root cause as two pre-existing instances)
- [x] Full suite: **2727 passed, 16 skipped** (up from 2482 at baseline)
- [x] Live-validated against this machine's real `/Applications` (152 apps:
      48 attention, 0 unknown, 104 managed); `--audit`, `--all --explain`,
      `--export json` (byte-clean, schema-valid), `--status managed`/
      `--status unknown` all correct
- [x] Simulated Homebrew CLI failure correctly routes every application to
      `unknown` with a populated error, never a false negative
- [x] Golden-fixture and regression tests independently verified to
      actually catch their target bugs (confirmed by briefly reverting each
      fix and watching the corresponding test fail, then re-confirming green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)